### PR TITLE
#5 Release v0.2.0 — createPipeHandlers, Model defaults, samples, and …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.0] - 2026-02-18
+
+### Added
+- `createPipeHandlers<T, Discriminant>(discriminant)` — creates a handler factory bound to a discriminant key, returning `match`, `matchWithDefault`, `map`, and `mapAll` in handlers-first (pipe-friendly) order: `(handlers) => (input) => result`
+- `TakeDiscriminant<T>` utility type exported from the public API
+- `samples/` directory with three real-world TypeScript examples: `fetch-state.ts`, `pipe-composition.ts`, `notifications.ts`
+
+### Changed
+- `createPipeHandlers` and `TakeDiscriminant` are now exported from the main package entry point
+- `Model<DiscriminantValue, Data, Discriminant>` — `Data` now defaults to `{}` and `Discriminant` defaults to `'type'`, enabling the common 1- and 2-argument forms (`Model<'idle'>`, `Model<'ok', { data: string }>`)
+- README fully restructured: table of contents, complete API reference with signatures and examples, `createPipeHandlers` pipe composition guide, type helper documentation, and real-world patterns
+
 ## [0.1.1] - 2026-02-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,39 @@
 # dismatch
 
-Type-safe pattern matching for TypeScript discriminated unions. Zero dependencies. Full type inference. Exhaustive checking at compile time.
+[![npm](https://img.shields.io/npm/v/dismatch)](https://www.npmjs.com/package/dismatch)
+[![license](https://img.shields.io/npm/l/dismatch)](./LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 
-Stop writing `switch` statements. Start matching.
+Type-safe pattern matching for TypeScript discriminated unions. Zero dependencies. Full type inference. Exhaustiveness enforced at compile time.
+
+```ts
+const area = match(shape)({
+  circle:    ({ radius })        => Math.PI * radius ** 2,
+  rectangle: ({ width, height }) => width * height,
+  triangle:  ({ base, height })  => (base * height) / 2,
+});
+```
+
+## Table of Contents
+
+- [Install](#install)
+- [Why dismatch](#why-dismatch)
+- [API Reference](#api-reference)
+  - [match](#match)
+  - [matchWithDefault](#matchwithdefault)
+  - [map](#map)
+  - [mapAll](#mapall)
+  - [is](#is)
+  - [isUnion](#isunion)
+  - [createPipeHandlers](#createpipehandlers)
+- [Type Helpers](#type-helpers)
+- [Custom Discriminant](#custom-discriminant)
+- [Patterns](#patterns)
+- [Clean Stack Traces](#clean-stack-traces)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
 
 ## Install
 
@@ -10,322 +41,437 @@ Stop writing `switch` statements. Start matching.
 npm install dismatch
 ```
 
-## The Problem
+---
 
-TypeScript discriminated unions are powerful, but working with them is tedious:
+## Why dismatch
+
+TypeScript discriminated unions are expressive, but switch/if-else chains on them are brittle. Add a new variant and the compiler stays silent while your 12 unhandled cases become silent bugs:
 
 ```ts
-type Shape =
-  | { type: 'circle'; radius: number }
-  | { type: 'rectangle'; width: number; height: number }
-  | { type: 'triangle'; base: number; height: number };
-
-// This gets old fast
+// ❌ Before — silent gaps, no compile-time safety
 function area(shape: Shape): number {
   switch (shape.type) {
-    case 'circle':
-      return Math.PI * shape.radius ** 2;
-    case 'rectangle':
-      return shape.width * shape.height;
-    case 'triangle':
-      return (shape.base * shape.height) / 2;
+    case 'circle':    return Math.PI * shape.radius ** 2;
+    case 'rectangle': return shape.width * shape.height;
+    // added 'triangle' to Shape last week — nobody noticed
   }
 }
 ```
 
-Add a new variant to `Shape` and the compiler won't tell you about the 14 switch statements you forgot to update.
+```ts
+// ✅ After — TypeScript errors at every unhandled call site
+function area(shape: Shape): number {
+  return match(shape)({
+    circle:    ({ radius })        => Math.PI * radius ** 2,
+    rectangle: ({ width, height }) => width * height,
+    triangle:  ({ base, height })  => (base * height) / 2,
+    // forget triangle → TypeScript error here
+  });
+}
+```
 
-## The Solution
+Add a new variant. TypeScript immediately flags every `match` call that hasn't been updated. No runtime surprises.
+
+---
+
+## API Reference
+
+### `match`
+
+Exhaustive pattern matching. Every variant must have a handler — TypeScript errors at compile time if one is missing, and throws at runtime if an unexpected value slips through (e.g. via `any` or an unchecked API response).
 
 ```ts
 import { match } from 'dismatch';
 
-const area = match(shape)({
-  circle: ({ radius }) => Math.PI * radius ** 2,
-  rectangle: ({ width, height }) => width * height,
-  triangle: ({ base, height }) => (base * height) / 2,
-});
-```
-
-Add a new variant. TypeScript screams at every `match` call that's missing a handler. That's the point.
-
-## API
-
-### `match(union)(handlers)` — Exhaustive Pattern Matching
-
-Every variant must have a handler. Exhaustiveness is enforced at two levels:
-
-- **Compile time** — TypeScript won't compile if any variant is missing a handler.
-- **Runtime** — if a value bypasses the type system (e.g. via `any`, a cast, or an unexpected API response), `match` throws rather than silently doing nothing.
-
-```ts
 type Result =
   | { type: 'ok'; data: string }
   | { type: 'error'; message: string }
   | { type: 'loading' };
 
-const response: Result = { type: 'ok', data: 'hello' };
-
-const message = match(response)({
-  ok: ({ data }) => `Got: ${data}`,
-  error: ({ message }) => `Failed: ${message}`,
-  loading: () => 'Loading...',
-});
-// message: "Got: hello"
-```
-
-The return type is inferred from your handlers. Return numbers, strings, objects, whatever you want — it just works.
-
-### `matchWithDefault(union)(handlers)` — Match With Fallback
-
-Handle some variants explicitly. Catch the rest with `Default`.
-
-```ts
-const label = matchWithDefault(response)({
-  error: ({ message }) => `Error: ${message}`,
-  Default: () => 'Everything is fine',
+const label = match(result)({
+  ok:      ({ data })    => `Data: ${data}`,
+  error:   ({ message }) => `Error: ${message}`,
+  loading: ()            => 'Loading…',
 });
 ```
 
-Useful when you only care about specific variants and want a catch-all for the rest.
+Handlers receive the variant's properties. The return type is inferred from all handlers — it can be a string, number, JSX element, Promise, another union, anything.
 
-### `map(union)(handlers)` — Partial Transformation
-
-Transform specific variants. The rest pass through unchanged.
+**Curried:** `match(value)` returns a reusable function. Bind once, apply different handler sets:
 
 ```ts
-const doubled = map(shape)({
-  circle: ({ type, radius }) => ({ type, radius: radius * 2 }),
-});
-// If shape is a circle: radius is doubled
-// If shape is anything else: returned as-is, untouched
+const handle = match(result);
+
+const statusCode = handle({ ok: () => 200,  error: () => 500, loading: () => 202 });
+const isHealthy  = handle({ ok: () => true, error: () => false, loading: () => false });
 ```
 
-Think of it as "update where type matches". Handlers you don't provide default to identity.
+---
 
-### `mapAll(union)(handlers)` — Full Transformation
+### `matchWithDefault`
 
-Like `map`, but every variant must have a handler. No freebies.
+Partial matching with a required `Default` fallback. Handle the variants you care about; `Default` catches everything else.
 
 ```ts
+import { matchWithDefault } from 'dismatch';
+
+const banner = matchWithDefault(result)({
+  error:   ({ message }) => `Something went wrong: ${message}`,
+  Default: ()            => 'All good',
+});
+```
+
+Use `matchWithDefault` when you genuinely don't need to handle every case. Prefer `match` everywhere else — exhaustive matching catches bugs at compile time when new variants are added.
+
+---
+
+### `map`
+
+Transform specific variants. The rest pass through **unchanged** (same object reference).
+
+```ts
+import { map } from 'dismatch';
+
+// Only circles grow; rectangles and triangles are returned as-is
+const bigger = map(shape)({
+  circle: ({ radius }) => ({ type: 'circle' as const, radius: radius * 2 }),
+});
+```
+
+Handlers receive the variant's **data fields** (not including the discriminant key). The return must include the full object — provide the `type` literal explicitly so the result is a valid union variant. Variants without a handler are identity-passed (same object reference).
+
+---
+
+### `mapAll`
+
+Like `map`, but every variant must have a handler. TypeScript errors if any are missing.
+
+```ts
+import { mapAll } from 'dismatch';
+
 const normalized = mapAll(shape)({
-  circle: ({ type, radius }) => ({ type, radius: Math.abs(radius) }),
-  rectangle: ({ type, width, height }) => ({ type, width: Math.abs(width), height: Math.abs(height) }),
-  triangle: ({ type, base, height }) => ({ type, base: Math.abs(base), height: Math.abs(height) }),
+  circle:    ({ radius })        => ({ type: 'circle'    as const, radius: Math.abs(radius) }),
+  rectangle: ({ width, height }) => ({ type: 'rectangle' as const, width:  Math.abs(width),
+                                                                    height: Math.abs(height) }),
+  triangle:  ({ base, height })  => ({ type: 'triangle'  as const, base:   Math.abs(base),
+                                                                    height: Math.abs(height) }),
 });
 ```
 
-### `is(union, type)` — Type Guard
+Use `mapAll` when transforming the whole union and you want the same exhaustiveness guarantee as `match`.
 
-Narrows a union to a specific variant. Works in `if` statements, `filter` calls, anywhere TypeScript expects a type predicate.
+---
+
+### `is`
+
+Type guard that narrows a union to a specific variant. Works in `if` blocks, `.filter()`, and anywhere TypeScript expects a type predicate.
 
 ```ts
 import { is } from 'dismatch';
 
 if (is(shape, 'circle')) {
-  // TypeScript knows: shape is { type: 'circle'; radius: number }
-  console.log(shape.radius);
+  console.log(shape.radius); // TypeScript knows: shape is { type: 'circle'; radius: number }
 }
 
-// Works great with array filtering
+// Array filtering — inferred element type is the narrowed variant
 const circles = shapes.filter((s) => is(s, 'circle'));
-// circles: { type: 'circle'; radius: number }[]
+//    ^? { type: 'circle'; radius: number }[]
 ```
 
-### `isUnion(value, discriminant?)` — Runtime Validation
+---
 
-Checks whether a value is a valid discriminated union (a non-null object with a string discriminant property). Useful at system boundaries — API responses, form data, anything you can't trust at compile time.
+### `isUnion`
+
+Runtime check that a value is a valid discriminated union (a non-null object with a string discriminant property). Useful at system boundaries — API responses, user input, external data.
 
 ```ts
 import { isUnion } from 'dismatch';
 
-isUnion({ type: 'circle', radius: 5 }); // true
-isUnion({ name: 'no type field' });      // false
-isUnion(null);                            // false
-isUnion('string');                        // false
+isUnion({ type: 'ok', data: 42 }); // true
+isUnion(null);                      // false
+isUnion('hello');                   // false
+isUnion({ name: 'no type field' }); // false
 
 // Custom discriminant
 isUnion({ kind: 'click', x: 10 }, 'kind'); // true
-isUnion({ type: 'circle' }, 'kind');        // false
 ```
 
-## Defining Your Unions
+---
 
-Use plain TypeScript types. Any object with a `type` string discriminant works:
+### `createPipeHandlers`
+
+Creates a handler factory **bound to a discriminant key**. Returns `match`, `matchWithDefault`, `map`, and `mapAll` in **handlers-first** curried order — `(handlers) => (input) => result` — making them directly composable inside any `pipe` utility without wrapper lambdas.
 
 ```ts
-type ApiResponse =
-  | { type: 'success'; data: User[] }
-  | { type: 'error'; code: number; message: string }
-  | { type: 'unauthorized' };
+import { createPipeHandlers } from 'dismatch';
+
+const shapeOps = createPipeHandlers<Shape, 'type'>('type');
+
+// Define handlers once — get back a reusable (shape: Shape) => number
+const getArea = shapeOps.match({
+  circle:    ({ radius })        => Math.PI * radius ** 2,
+  rectangle: ({ width, height }) => width * height,
+  triangle:  ({ base, height })  => (base * height) / 2,
+});
+
+getArea(circle);    // 78.54…
+getArea(rectangle); // 24
+
+// Apply to an entire array — no wrapper lambdas
+const areas = shapes.map(getArea);
+
+// Compose directly in a pipe
+import { pipe } from 'fp-ts/function';
+
+const result = pipe(
+  shape,
+  shapeOps.match({
+    circle:    () => 'round',
+    rectangle: () => 'flat',
+    triangle:  () => 'pointy',
+  }),
+);
 ```
 
-Or use the `Model` helper type for cleaner definitions:
+Regular `match(value)(handlers)` is great for one-off decisions. `createPipeHandlers` shines when you need to **reuse the same handler set** across many values or **compose** operations in a pipeline:
+
+| Use case | Prefer |
+|---|---|
+| One-off match on a single value | `match(value)(handlers)` |
+| Apply the same handler set to an array or stream | `createPipeHandlers` |
+| Compose multiple operations in a `pipe` | `createPipeHandlers` |
+| Pass a handler as a callback / higher-order function | `createPipeHandlers` |
+
+See the [`samples/`](./samples) directory for end-to-end real-world examples.
+
+---
+
+## Type Helpers
+
+### `Model<DiscriminantValue, Data?, Discriminant?>`
+
+Constructs a single variant type. Both `Data` and `Discriminant` are optional — `Data` defaults to `{}` and `Discriminant` defaults to `'type'`.
 
 ```ts
 import type { Model } from 'dismatch';
 
+// Minimal — empty data payload, 'type' discriminant
+type Idle    = Model<'idle'>;
+// → { type: 'idle' }
+
+// With data fields
 type Success = Model<'success', { data: User[] }>;
-type ApiError = Model<'error', { code: number; message: string }>;
-type Unauthorized = Model<'unauthorized', {}>;
+// → { type: 'success'; data: User[] }
 
-type ApiResponse = Success | ApiError | Unauthorized;
+type Failure = Model<'failure', { error: string; retries: number }>;
+// → { type: 'failure'; error: string; retries: number }
+
+type FetchState = Idle | Success | Failure;
 ```
 
-## Custom Discriminant Property
-
-By default, dismatch uses `type` as the discriminant property. If your unions use a different field — common in API responses that use `status` — pass it as a second argument to any function:
+With a custom discriminant key:
 
 ```ts
-type ApiResponse<T> =
-  | { status: 'success'; data: T }
-  | { status: 'error'; message: string; code: number }
-  | { status: 'loading' };
+type DogVariant = Model<'dog', { name: string }, 'kind'>;
+// → { kind: 'dog'; name: string }
+```
 
-const response: ApiResponse<User[]> = await fetchUsers();
+### `UnionByArray<T, Discriminant?>`
 
-// Handlers can be async — the inferred return type becomes Promise<...>
-const users = await match(response, 'status')({
-  success: async ({ data }) => normalize(data),
-  error: ({ message, code }) => Promise.reject(new ApiError(message, code)),
-  loading: async () => [],
+Derives a union type from a tuple of `Model` types. Useful when you define variants as a tuple (for iteration, schema generation, or documentation) and need the union type from it.
+
+```ts
+import type { Model, UnionByArray } from 'dismatch';
+
+type Variants = [
+  Model<'circle',    { radius: number }>,
+  Model<'rectangle', { width: number; height: number }>,
+];
+
+type Shape = UnionByArray<Variants>;
+// → Model<'circle', { radius: number }> | Model<'rectangle', { width: number; height: number }>
+```
+
+### `TakeDiscriminant<T>`
+
+Extracts valid discriminant key candidates from a union type — keys whose value types are narrow (non-wide) strings. Used internally by `createPipeHandlers` to constrain the discriminant argument.
+
+```ts
+import type { TakeDiscriminant } from 'dismatch';
+
+type D = TakeDiscriminant<Shape>; // 'type'
+type A = TakeDiscriminant<Animal>; // 'kind'
+```
+
+---
+
+## Custom Discriminant
+
+All functions accept an optional discriminant parameter (default: `'type'`). Pass your field name as a second argument to match unions that use `kind`, `status`, `tag`, or any other key:
+
+```ts
+type Animal =
+  | { kind: 'dog';  name: string }
+  | { kind: 'cat';  lives: number }
+  | { kind: 'bird'; canFly: boolean };
+
+const sound = match(animal, 'kind')({
+  dog:  ({ name })   => `${name} barks`,
+  cat:  ()           => 'meow',
+  bird: ({ canFly }) => canFly ? 'tweet' : 'squawk',
 });
 ```
 
-Every function in the API accepts the discriminant as an optional extra argument:
+Every function in the API follows the same signature:
 
 ```ts
-matchWithDefault(response, 'status')({ error: ..., Default: ... });
-map(response, 'status')({ error: ... });
-mapAll(response, 'status')({ success: ..., error: ..., loading: ... });
-is(response, 'success', 'status');
-isUnion(response, 'status');
+matchWithDefault(animal, 'kind')({ dog: ..., Default: ... });
+map(animal,      'kind')({ cat: ... });
+mapAll(animal,   'kind')({ dog: ..., cat: ..., bird: ... });
+is(animal, 'dog',  'kind');
+isUnion(animal,    'kind');
 ```
 
-TypeScript infers the discriminant from the type, so you keep full type safety regardless of what field name you use.
-
-## Curried by Design
-
-Every function returns a reusable matcher. Bind the data once, apply different handlers later:
+With `createPipeHandlers`, pass the discriminant once at creation — all returned functions inherit it:
 
 ```ts
-const handleResponse = match(response);
+const animalOps = createPipeHandlers<Animal, 'kind'>('kind');
 
-// Use the same bound value with different matchers
-const statusCode = handleResponse({
-  ok: () => 200,
-  error: ({ code }) => code,
-  loading: () => 0,
+const describe = animalOps.match({
+  dog:  ({ name })   => `Dog: ${name}`,
+  cat:  ({ lives })  => `Cat with ${lives} lives`,
+  bird: ({ canFly }) => `Bird (${canFly ? 'flies' : 'flightless'})`,
 });
 
-const isHealthy = handleResponse({
-  ok: () => true,
-  error: () => false,
-  loading: () => false,
-});
+describe(dog);  // 'Dog: Rex'
+describe(bird); // 'Bird (flies)'
 ```
 
-## Real-World Examples
+---
 
-### State Machines
+## Patterns
+
+### Rendering UI
+
+Use `match` to map every state to a view — exhaustively, without else branches. Adding a new state variant forces you to update every render site at compile time:
 
 ```ts
-type AuthState =
-  | { type: 'logged_out' }
-  | { type: 'logging_in'; email: string }
-  | { type: 'logged_in'; user: User; token: string }
-  | { type: 'error'; reason: string };
+type FetchState<T> =
+  | { type: 'idle' }
+  | { type: 'loading' }
+  | { type: 'success'; data: T; stale: boolean }
+  | { type: 'failure'; error: string };
 
-function renderAuth(state: AuthState) {
+function UserList({ state }: { state: FetchState<User[]> }) {
   return match(state)({
-    logged_out: () => renderLoginForm(),
-    logging_in: ({ email }) => renderSpinner(`Signing in ${email}...`),
-    logged_in: ({ user }) => renderDashboard(user),
-    error: ({ reason }) => renderError(reason),
+    idle:    ()             => <button onClick={fetch}>Load users</button>,
+    loading: ()             => <Spinner />,
+    success: ({ data })     => <ul>{data.map(renderUser)}</ul>,
+    failure: ({ error })    => <ErrorBanner message={error} />,
   });
 }
 ```
 
-### Reducer Actions
+### Reducer / State Machine
 
 ```ts
 type Action =
-  | { type: 'increment'; amount: number }
-  | { type: 'decrement'; amount: number }
+  | { type: 'increment'; by: number }
+  | { type: 'decrement'; by: number }
   | { type: 'reset' };
 
-function reducer(state: number, action: Action): number {
-  return match(action)({
-    increment: ({ amount }) => state + amount,
-    decrement: ({ amount }) => state - amount,
-    reset: () => 0,
+const reduce = (state: number, action: Action): number =>
+  match(action)({
+    increment: ({ by }) => state + by,
+    decrement: ({ by }) => state - by,
+    reset:     ()       => 0,
   });
-}
 ```
 
-### API Response Handling
-
-```ts
-type FetchResult<T> =
-  | { type: 'pending' }
-  | { type: 'fulfilled'; data: T }
-  | { type: 'rejected'; error: Error };
-
-function unwrapOr<T>(result: FetchResult<T>, fallback: T): T {
-  return matchWithDefault(result)({
-    fulfilled: ({ data }) => data,
-    Default: () => fallback,
-  });
-}
-```
-
-### Selective Updates
+### Selective State Transitions with `map`
 
 ```ts
 type Notification =
   | { type: 'email'; subject: string; read: boolean }
-  | { type: 'sms'; body: string; read: boolean }
-  | { type: 'push'; title: string; read: boolean };
+  | { type: 'sms';   body: string;    read: boolean }
+  | { type: 'push';  title: string;   read: boolean };
 
-// Mark only emails as read, leave everything else alone
-const markEmailsRead = (n: Notification) =>
+// Mark only emails as read — SMS and push pass through as the same object reference
+const markEmailRead = (n: Notification): Notification =>
   map(n)({
-    email: ({ type, subject }) => ({ type, subject, read: true }),
+    email: ({ subject }) => ({ type: 'email' as const, subject, read: true }),
   });
 ```
 
+### Batch Operations with `createPipeHandlers`
+
+```ts
+const shapeOps = createPipeHandlers<Shape, 'type'>('type');
+
+// Build the matcher once
+const getArea = shapeOps.match({
+  circle:    ({ radius })        => Math.PI * radius ** 2,
+  rectangle: ({ width, height }) => width * height,
+  triangle:  ({ base, height })  => (base * height) / 2,
+});
+
+// Apply to any collection — no wrapper lambdas, no ceremony
+const areas         = shapes.map(getArea);
+const totalArea     = areas.reduce((sum, a) => sum + a, 0);
+const largestIndex  = areas.indexOf(Math.max(...areas));
+```
+
+### Pipe Composition
+
+```ts
+import { pipe } from 'fp-ts/function'; // or any pipe utility
+
+const shapeOps = createPipeHandlers<Shape, 'type'>('type');
+
+const describeArea = pipe(
+  shape,
+  shapeOps.match({
+    circle:    ({ radius })        => Math.PI * radius ** 2,
+    rectangle: ({ width, height }) => width * height,
+    triangle:  ({ base, height })  => (base * height) / 2,
+  }),
+  (area) => `Area: ${area.toFixed(2)} sq units`,
+);
+```
+
+---
+
 ## Clean Stack Traces
 
-When dismatch throws an error (e.g. you pass a non-union value), the stack trace points directly to your call site — not into minified library internals.
-
-Most libraries don't do this. Without stack trace clearing, you get noise like:
+When dismatch throws (e.g. an unvalidated API response bypasses the type system), the stack trace points to **your call site** — not into minified library internals.
 
 ```
+// ❌ Typical library — your code is buried under framework frames
 Error: Data is not of type discriminated union!
-    at Object.<anonymous> (node_modules/some-lib/dist/index.cjs:1:3842)
-    at Object.<anonymous> (node_modules/some-lib/dist/index.cjs:1:1205)
-    at Object.<anonymous> (node_modules/some-lib/dist/index.cjs:1:892)
-    at handleResponse (src/api/users.ts:27:18)
-```
+    at validate  (node_modules/dismatch/dist/index.cjs:1:892)
+    at match     (node_modules/dismatch/dist/index.cjs:1:1205)
+    at handleResponse (src/api.ts:27:18)
 
-The real call site is buried under a wall of minified package frames. With dismatch, the stack starts where you actually made the mistake:
-
-```
+// ✅ dismatch — stack starts where you made the call
 Error: Data is not of type discriminated union!
-    at handleResponse (src/api/users.ts:27:18)
+    at handleResponse (src/api.ts:27:18)
 ```
 
-This works via `Error.captureStackTrace` (V8/Node.js). In environments that don't support it the error is still thrown — the stack just isn't trimmed.
+Powered by `Error.captureStackTrace` (V8/Node.js). In environments without it the error still throws — the stack just isn't trimmed.
 
-## Scripts
+---
+
+## Contributing
 
 ```bash
-npm run build        # Compile TypeScript
-npm test             # Run tests
-npm run test:watch   # Run tests in watch mode
-npm run ts:ci        # Type check (no emit)
+npm test             # run the test suite
+npm run test:watch   # watch mode
+npm run ts:ci        # type-check without emitting
+npm run build        # compile to lib/
 ```
+
+---
 
 ## License
 
-MIT (refer to LICENSE file)
+MIT — see [LICENSE](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dismatch",
   "description": "A lightweight discriminated unions library for TypeScript",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",

--- a/samples/fetch-state.ts
+++ b/samples/fetch-state.ts
@@ -1,0 +1,157 @@
+/**
+ * Async Data Fetching — Discriminated Union State Machine
+ *
+ * Models the full lifecycle of an async operation as a discriminated union
+ * with four states: idle → loading → success | failure.
+ *
+ * Demonstrates:
+ *   - Defining a parameterised state union with Model<>
+ *   - match() for exhaustive view rendering / status derivation
+ *   - map() for state transitions that only touch one variant
+ *   - matchWithDefault() for "I only care about this one case"
+ *   - createPipeHandlers for reusable, pipe-friendly handlers
+ */
+
+import {
+  match,
+  map,
+  matchWithDefault,
+  createPipeHandlers,
+  isUnion,
+} from 'dismatch';
+import type { Model } from 'dismatch';
+
+// ── Domain types ──────────────────────────────────────────────────────────────
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+/**
+ * Four-state async model. `stale` on success lets us distinguish a fresh
+ * result from one being re-fetched in the background.
+ */
+type FetchState<T> =
+  | Model<'idle'>
+  | Model<'loading'>
+  | Model<'success', { data: T; stale: boolean }>
+  | Model<'failure', { error: string; retries: number }>;
+
+// ── State transitions (pure functions, no side effects) ───────────────────────
+
+/** Start a fresh fetch — always moves to loading. */
+function startFetch<T>(state: FetchState<T>): FetchState<T> {
+  return match(state)({
+    idle:    () => ({ type: 'loading' } as const),
+    loading: () => state,                                    // already in-flight
+    success: ({ data }) => ({ type: 'success', data, stale: true } as const), // background refresh
+    failure: () => ({ type: 'loading' } as const),
+  });
+}
+
+/** Record a successful response. */
+function onSuccess<T>(data: T): FetchState<T> {
+  return { type: 'success', data, stale: false };
+}
+
+/** Record a failure, incrementing the retry counter. */
+function onFailure<T>(state: FetchState<T>, error: string): FetchState<T> {
+  // map() handler parameters are typed as the variant's Data (without the discriminant key).
+  // Include type: 'failure' as const in the return to reconstruct the full variant.
+  return map(state)({
+    failure: ({ retries }) => ({ type: 'failure' as const, error, retries: retries + 1 }),
+  });
+}
+
+// ── Derived values ─────────────────────────────────────────────────────────────
+
+/** Is there an in-flight request (including stale background refresh)? */
+function isLoading<T>(state: FetchState<T>): boolean {
+  return match(state)({
+    idle:    () => false,
+    loading: () => true,
+    success: ({ stale }) => stale,
+    failure: () => false,
+  });
+}
+
+/** Unwrap data, or return a fallback. */
+function dataOr<T>(state: FetchState<T>, fallback: T): T {
+  return matchWithDefault(state)({
+    success: ({ data }) => data,
+    Default: () => fallback,
+  });
+}
+
+/** Human-readable status for logging / UI headers. */
+function statusLabel<T>(state: FetchState<T>): string {
+  return match(state)({
+    idle:    () => 'Not started',
+    loading: () => 'Loading…',
+    success: ({ stale }) => stale ? 'Refreshing…' : 'Up to date',
+    failure: ({ error, retries }) => `Failed (attempt ${retries}): ${error}`,
+  });
+}
+
+// ── createPipeHandlers — reusable, pipe-friendly handlers ──────────────────────
+
+/**
+ * Bind handlers to FetchState<User[]> once. The returned functions have the
+ * shape `(state: FetchState<User[]>) => Result`, so they can be passed directly
+ * to Array.map, pipe utilities, or stored as module-level constants.
+ */
+const userFetchOps = createPipeHandlers<FetchState<User[]>, 'type'>('type');
+
+const getUserCount = userFetchOps.match({
+  idle:    () => 0,
+  loading: () => 0,
+  success: ({ data }) => data.length,
+  failure: () => 0,
+});
+
+const getStatusMessage = userFetchOps.match({
+  idle:    () => 'Waiting for data',
+  loading: () => 'Fetching users…',
+  success: ({ data, stale }) =>
+    `${data.length} users loaded${stale ? ' (refreshing)' : ''}`,
+  failure: ({ error }) => `Could not load users: ${error}`,
+});
+
+// ── Simulation ─────────────────────────────────────────────────────────────────
+
+let state: FetchState<User[]> = { type: 'idle' };
+
+console.log(statusLabel(state));            // 'Not started'
+console.log(isLoading(state));              // false
+
+state = startFetch(state);
+console.log(statusLabel(state));            // 'Loading…'
+console.log(isLoading(state));              // true
+
+state = onSuccess<User[]>([
+  { id: 1, name: 'Alice', email: 'alice@example.com' },
+  { id: 2, name: 'Bob',   email: 'bob@example.com' },
+]);
+console.log(statusLabel(state));            // 'Up to date'
+console.log(getUserCount(state));           // 2
+console.log(getStatusMessage(state));       // '2 users loaded'
+
+state = startFetch(state);                  // background refresh → stale
+console.log(isLoading(state));              // true (stale = true)
+console.log(getStatusMessage(state));       // '2 users loaded (refreshing)'
+
+// ── Runtime boundary: validate external data before matching ──────────────────
+
+function processApiResponse(raw: unknown): string {
+  if (!isUnion(raw)) {
+    return 'Invalid response format';
+  }
+  // We know it's a valid union — hand off to our typed handlers
+  return matchWithDefault(raw as FetchState<User[]>)({
+    success: ({ data }) => `Received ${data.length} records`,
+    failure: ({ error }) => `Server error: ${error}`,
+    Default: () => 'Unexpected state',
+  });
+}

--- a/samples/notifications.ts
+++ b/samples/notifications.ts
@@ -1,0 +1,159 @@
+/**
+ * Notification Centre
+ *
+ * A realistic notification system that combines multiple dismatch functions
+ * to manage a heterogeneous collection of notification variants.
+ *
+ * Demonstrates:
+ *   - match() for rendering and deriving values
+ *   - matchWithDefault() for partial handling (e.g. a quick-action toolbar)
+ *   - map() for targeted in-place mutations (mark one type as read)
+ *   - mapAll() for full normalisation across all variants
+ *   - is() for type-safe filtering and narrowing
+ *   - createPipeHandlers for reusable, array-friendly operations
+ */
+
+import { match, matchWithDefault, map, mapAll, is, createPipeHandlers } from 'dismatch';
+import type { Model } from 'dismatch';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+type Notification =
+  | Model<'email', { from: string; subject: string; read: boolean; starred: boolean }>
+  | Model<'sms',   { from: string; body: string;    read: boolean }>
+  | Model<'push',  { app: string;  title: string;   read: boolean; urgent: boolean }>;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const notifOps = createPipeHandlers<Notification, 'type'>('type');
+
+/** Single-line preview text shown in the notification list. */
+const getPreview = notifOps.match({
+  email: ({ from, subject }) => `📧 ${from}: ${subject}`,
+  sms:   ({ from, body })    => `💬 ${from}: ${body.slice(0, 60)}`,
+  push:  ({ app, title })    => `🔔 ${app}: ${title}`,
+});
+
+/** Importance score — urgent push notes bubble to the top. */
+const getPriority = notifOps.match({
+  email: ({ starred }) => starred ? 2 : 1,
+  sms:   ()            => 1,
+  push:  ({ urgent })  => urgent ? 3 : 1,
+});
+
+/** Is this notification unread? */
+const isUnread = notifOps.match({
+  email: ({ read }) => !read,
+  sms:   ({ read }) => !read,
+  push:  ({ read }) => !read,
+});
+
+/** Mark a notification as read — each variant carries `read` so we handle all. */
+const markRead = notifOps.mapAll({
+  email: (n) => ({ ...n, read: true }),
+  sms:   (n) => ({ ...n, read: true }),
+  push:  (n) => ({ ...n, read: true }),
+});
+
+/**
+ * Quick-action label for a toolbar button.
+ * Only emails have a "Star" action — everything else gets "Dismiss".
+ */
+const getAction = notifOps.matchWithDefault({
+  email: ({ starred }) => starred ? 'Unstar' : 'Star',
+  Default: () => 'Dismiss',
+});
+
+// ── Notification store (plain array, no framework required) ───────────────────
+
+class NotificationStore {
+  private items: Notification[] = [];
+
+  add(notification: Notification): void {
+    this.items.push(notification);
+  }
+
+  /** All notifications sorted by priority (highest first). */
+  get sorted(): Notification[] {
+    return [...this.items].sort((a, b) => getPriority(b) - getPriority(a));
+  }
+
+  /** Unread count — no boilerplate, handlers slot straight into filter. */
+  get unreadCount(): number {
+    return this.items.filter(isUnread).length;
+  }
+
+  /** All email notifications, typed as the email variant. */
+  get emails() {
+    return this.items.filter((n) => is(n, 'email'));
+    //                              ^? { type: 'email'; from: string; ... }[]
+  }
+
+  /** Urgent push notifications only. */
+  get urgentPushes() {
+    return this.items
+      .filter((n) => is(n, 'push'))
+      .filter(({ urgent }) => urgent);
+  }
+
+  /** Mark every notification as read. */
+  markAllRead(): void {
+    this.items = this.items.map(markRead);
+  }
+
+  /**
+   * Mark only SMS notifications as read — emails and push pass through
+   * unchanged (same object reference), no unnecessary allocations.
+   */
+  markSmsRead(): void {
+    this.items = this.items.map((n) =>
+      map(n)({
+        sms: (sms) => ({ ...sms, read: true }),
+      }),
+    );
+  }
+
+  /** Render a plain-text summary of every notification. */
+  renderList(): string[] {
+    return this.sorted.map((n) => {
+      const unread = isUnread(n) ? '● ' : '  ';
+      const action = getAction(n);
+      return `${unread}${getPreview(n)}  [${action}]`;
+    });
+  }
+
+  /** Detailed view — exhaustive, so adding a new variant is a compile error here. */
+  renderDetail(n: Notification): string {
+    return match(n)({
+      email: ({ from, subject, starred, read }) =>
+        `Email from ${from}\nSubject: ${subject}\nStarred: ${starred} | Read: ${read}`,
+      sms: ({ from, body, read }) =>
+        `SMS from ${from}\n${body}\nRead: ${read}`,
+      push: ({ app, title, urgent, read }) =>
+        `Push from ${app}\n${title}\nUrgent: ${urgent} | Read: ${read}`,
+    });
+  }
+}
+
+// ── Simulation ─────────────────────────────────────────────────────────────────
+
+const store = new NotificationStore();
+
+store.add({ type: 'email', from: 'boss@corp.com', subject: 'Q4 review',  read: false, starred: true });
+store.add({ type: 'sms',   from: '+1-555-0100',   body:    'Your code is ready for pickup.', read: false });
+store.add({ type: 'push',  app: 'GitHub',         title:   'PR #42 merged', read: true, urgent: false });
+store.add({ type: 'push',  app: 'PagerDuty',      title:   '🚨 Prod alert: high error rate', read: false, urgent: true });
+store.add({ type: 'email', from: 'news@digest.io', subject: 'Weekly digest', read: true, starred: false });
+
+console.log(`Unread: ${store.unreadCount}`);  // 3
+console.log(`Emails: ${store.emails.length}`); // 2
+console.log(`Urgent: ${store.urgentPushes.length}`); // 1
+
+console.log('\n--- Notification list (sorted by priority) ---');
+store.renderList().forEach((line) => console.log(line));
+
+store.markSmsRead();
+console.log(`\nAfter marking SMS read — unread: ${store.unreadCount}`); // 2
+
+store.markAllRead();
+console.log(`After marking all read  — unread: ${store.unreadCount}`); // 0

--- a/samples/pipe-composition.ts
+++ b/samples/pipe-composition.ts
@@ -1,0 +1,146 @@
+/**
+ * Pipe Composition with createPipeHandlers
+ *
+ * createPipeHandlers inverts the curry order — `(handlers) => (input) => result`
+ * — so the returned functions slot directly into any pipe utility, array method,
+ * or higher-order function without wrapper lambdas.
+ *
+ * Demonstrates:
+ *   - createPipeHandlers for handlers-first currying
+ *   - Composing match + map steps in a pipeline
+ *   - Array.map / Array.filter without boilerplate
+ *   - A minimal pipe() helper (drop-in compatible with fp-ts, ramda, etc.)
+ */
+
+import { createPipeHandlers, is } from 'dismatch';
+import type { Model } from 'dismatch';
+
+// ── A tiny pipe() — swap this for fp-ts/function pipe if you use it ──────────
+
+function pipe<A>(a: A): A;
+function pipe<A, B>(a: A, f1: (a: A) => B): B;
+function pipe<A, B, C>(a: A, f1: (a: A) => B, f2: (b: B) => C): C;
+function pipe<A, B, C, D>(a: A, f1: (a: A) => B, f2: (b: B) => C, f3: (c: C) => D): D;
+function pipe(value: unknown, ...fns: Array<(x: unknown) => unknown>): unknown {
+  return fns.reduce((acc, fn) => fn(acc), value);
+}
+
+// ── Domain: geometric shapes ───────────────────────────────────────────────────
+
+type Circle    = Model<'circle',    { radius: number }>;
+type Rectangle = Model<'rectangle', { width: number; height: number }>;
+type Triangle  = Model<'triangle',  { base: number; height: number }>;
+type Shape     = Circle | Rectangle | Triangle;
+
+// ── Domain: normalised report ─────────────────────────────────────────────────
+
+interface ShapeReport {
+  name: string;
+  area: number;
+  perimeter: number;
+  description: string;
+}
+
+// ── Handler factory — bound to 'type' once ────────────────────────────────────
+
+const shapeOps = createPipeHandlers<Shape, 'type'>('type');
+
+// Each call to shapeOps.match / shapeOps.map returns a
+// `(shape: Shape) => T` function — ready for pipe / array methods.
+
+const getName = shapeOps.match({
+  circle:    () => 'Circle',
+  rectangle: () => 'Rectangle',
+  triangle:  () => 'Triangle',
+});
+
+const getArea = shapeOps.match({
+  circle:    ({ radius })        => Math.PI * radius ** 2,
+  rectangle: ({ width, height }) => width * height,
+  triangle:  ({ base, height })  => (base * height) / 2,
+});
+
+const getPerimeter = shapeOps.match({
+  circle:    ({ radius })        => 2 * Math.PI * radius,
+  rectangle: ({ width, height }) => 2 * (width + height),
+  triangle:  ({ base, height })  => {
+    // assume right triangle: hypotenuse = √(base² + height²)
+    const hyp = Math.sqrt(base ** 2 + height ** 2);
+    return base + height + hyp;
+  },
+});
+
+/**
+ * Normalise all dimensions to absolute values without touching other variants.
+ *
+ * map() handler parameters are typed as the variant's Data (without the discriminant).
+ * Provide the type literal explicitly in the return to reconstruct the full variant.
+ */
+const normalise = shapeOps.map({
+  circle:    ({ radius })        => ({ type: 'circle'    as const, radius: Math.abs(radius) }),
+  rectangle: ({ width, height }) => ({ type: 'rectangle' as const, width:  Math.abs(width),
+                                                                    height: Math.abs(height) }),
+  triangle:  ({ base, height })  => ({ type: 'triangle'  as const, base:   Math.abs(base),
+                                                                    height: Math.abs(height) }),
+});
+
+// ── Build a full report in a pipe ─────────────────────────────────────────────
+
+function buildReport(raw: Shape): ShapeReport {
+  return pipe(
+    raw,
+    normalise,                          // ensure positive dimensions
+    (shape) => ({
+      name:        getName(shape),
+      area:        getArea(shape),
+      perimeter:   getPerimeter(shape),
+      description: `${getName(shape)} with area ${getArea(shape).toFixed(2)}`,
+    }),
+  );
+}
+
+// ── Batch processing — no wrapper lambdas ─────────────────────────────────────
+
+const catalog: Shape[] = [
+  { type: 'circle',    radius: 5 },
+  { type: 'rectangle', width: 4, height: 6 },
+  { type: 'triangle',  base: 3, height: 4 },
+  { type: 'circle',    radius: -7 },   // negative — normalise will fix this
+  { type: 'rectangle', width: 10, height: 2 },
+];
+
+// Apply the full pipeline to every shape — getArea is a plain function reference
+const reports: ShapeReport[] = catalog.map(buildReport);
+
+// Filter using is() — no wrapper, correct inferred type
+const circles = catalog.filter((s) => is(s, 'circle'));
+//    ^? Circle[]
+
+const circleAreas = circles.map(getArea);
+
+// Sort shapes by area descending — again, getArea slots in directly
+const byAreaDesc = [...catalog]
+  .map(normalise)
+  .sort((a, b) => getArea(b) - getArea(a));
+
+// ── Multiple handler sets on the same factory ─────────────────────────────────
+
+/**
+ * Different teams / modules can define their own handler sets using the same
+ * shapeOps instance — handlers are just plain objects, no coupling.
+ */
+
+const getShortLabel = shapeOps.match({
+  circle:    ({ radius })        => `⬤ r=${radius}`,
+  rectangle: ({ width, height }) => `▬ ${width}×${height}`,
+  triangle:  ({ base, height })  => `▲ b=${base} h=${height}`,
+});
+
+const getColor = shapeOps.matchWithDefault({
+  circle: () => '#4f86f7',           // blue for circles
+  Default: () => '#f7a24f',          // orange for everything else
+});
+
+console.log(reports.map((r) => `${r.name}: area=${r.area.toFixed(2)}`));
+console.log(catalog.map(getShortLabel));
+console.log(catalog.map(getColor));

--- a/samples/tsconfig.json
+++ b/samples/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "DOM"],
+    "paths": {
+      "dismatch": ["../src/index.ts"]
+    }
+  },
+  "include": ["./**/*.ts"]
+}

--- a/src/__tests__/module.test.ts
+++ b/src/__tests__/module.test.ts
@@ -144,3 +144,29 @@ describe('is with custom discriminant', () => {
     }
   });
 });
+
+describe('is — array filtering', () => {
+  const shapes: Shape[] = [
+    { type: 'circle', radius: 5 },
+    { type: 'rectangle', width: 4, height: 6 },
+    { type: 'circle', radius: 10 },
+    { type: 'rectangle', width: 2, height: 3 },
+  ];
+
+  it('should filter to only circle variants', () => {
+    const circles = shapes.filter((s) => is(s, 'circle'));
+    expect(circles).toHaveLength(2);
+    expect(circles.every((s) => s.type === 'circle')).toBe(true);
+  });
+
+  it('should filter to only rectangle variants', () => {
+    const rectangles = shapes.filter((s) => is(s, 'rectangle'));
+    expect(rectangles).toHaveLength(2);
+    expect(rectangles.every((s) => s.type === 'rectangle')).toBe(true);
+  });
+
+  it('should return empty array when no variants match', () => {
+    const result = shapes.filter((s) => is(s, 'triangle' as any));
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/__tests__/unions.test.ts
+++ b/src/__tests__/unions.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { match, matchWithDefault, map, mapAll } from '../unions';
+import {
+  match,
+  matchWithDefault,
+  map,
+  mapAll,
+  createPipeHandlers,
+} from '../unions';
 
 type Shape =
   | { type: 'circle'; radius: number }
@@ -317,7 +323,10 @@ describe('match with custom discriminant', () => {
 
 describe('matchWithDefault with custom discriminant', () => {
   it('should match specific variant with custom discriminant', () => {
-    const result = matchWithDefault(dog, 'kind')({
+    const result = matchWithDefault(
+      dog,
+      'kind',
+    )({
       dog: ({ name }) => `Dog: ${name}`,
       Default: () => 'Unknown animal',
     });
@@ -325,7 +334,10 @@ describe('matchWithDefault with custom discriminant', () => {
   });
 
   it('should fall back to Default for unhandled variant', () => {
-    const result = matchWithDefault(bird, 'kind')({
+    const result = matchWithDefault(
+      bird,
+      'kind',
+    )({
       dog: ({ name }) => `Dog: ${name}`,
       Default: () => 'Unknown animal',
     });
@@ -335,14 +347,20 @@ describe('matchWithDefault with custom discriminant', () => {
 
 describe('map with custom discriminant', () => {
   it('should transform matched variant with custom discriminant', () => {
-    const result = map(cat, 'kind')({
+    const result = map(
+      cat,
+      'kind',
+    )({
       cat: ({ kind, lives }) => ({ kind, lives: lives - 1 }),
     });
     expect(result).toEqual({ kind: 'cat', lives: 8 });
   });
 
   it('should pass through unmatched variant with custom discriminant', () => {
-    const result = map(dog, 'kind')({
+    const result = map(
+      dog,
+      'kind',
+    )({
       cat: ({ kind, lives }) => ({ kind, lives: lives - 1 }),
     });
     expect(result).toBe(dog);
@@ -351,11 +369,216 @@ describe('map with custom discriminant', () => {
 
 describe('mapAll with custom discriminant', () => {
   it('should transform all variants correctly with custom discriminant', () => {
-    const result = mapAll(dog, 'kind')({
+    const result = mapAll(
+      dog,
+      'kind',
+    )({
       dog: ({ kind, name }) => ({ kind, name: name.toUpperCase() }),
       cat: ({ kind, lives }) => ({ kind, lives: lives + 1 }),
       bird: ({ kind, canFly }) => ({ kind, canFly: !canFly }),
     });
     expect(result).toEqual({ kind: 'dog', name: 'REX' });
+  });
+});
+
+describe('createPipeHandlers', () => {
+  const shapeOps = createPipeHandlers<Shape, 'type'>('type');
+  const animalOps = createPipeHandlers<Animal, 'kind'>('kind');
+
+  const shapeMatcher = {
+    circle: ({ radius }) => Math.PI * radius ** 2,
+    rectangle: ({ width, height }) => width * height,
+    triangle: ({ base, height }) => (base * height) / 2,
+  };
+
+  describe('match', () => {
+    it('should return correct result for circle variant', () => {
+      const fn = shapeOps.match(shapeMatcher);
+      expect(fn(circle)).toBeCloseTo(Math.PI * 25);
+    });
+
+    it('should return correct result for rectangle variant', () => {
+      const fn = shapeOps.match(shapeMatcher);
+      expect(fn(rectangle)).toBe(24);
+    });
+
+    it('should return correct result for triangle variant', () => {
+      const fn = shapeOps.match(shapeMatcher);
+      expect(fn(triangle)).toBe(15);
+    });
+
+    it('should return a reusable function', () => {
+      const fn = shapeOps.match(shapeMatcher);
+      expect(fn(circle)).toBeCloseTo(Math.PI * 25);
+      expect(fn(rectangle)).toBe(24);
+    });
+
+    it('should throw for invalid input', () => {
+      const fn = shapeOps.match(shapeMatcher);
+      expect(() => fn(null as any)).toThrow(
+        'Data is not of type discriminated union!',
+      );
+    });
+  });
+
+  describe('matchWithDefault', () => {
+    it('should match explicit variant', () => {
+      const fn = shapeOps.matchWithDefault({
+        circle: ({ radius }) => `Circle r=${radius}`,
+        Default: () => 'Other',
+      });
+      expect(fn(circle)).toBe('Circle r=5');
+    });
+
+    it('should fall back to Default for unhandled variant', () => {
+      const fn = shapeOps.matchWithDefault({
+        circle: ({ radius }) => `Circle r=${radius}`,
+        Default: () => 'Other',
+      });
+      expect(fn(rectangle)).toBe('Other');
+    });
+
+    it('should throw for invalid input', () => {
+      const fn = shapeOps.matchWithDefault({ Default: () => 'x' });
+      expect(() => fn(null as any)).toThrow(
+        'Data is not of type discriminated union!',
+      );
+    });
+  });
+
+  describe('map', () => {
+    it('should transform matched variant', () => {
+      const fn = shapeOps.map({
+        circle: ({ type, radius }) => ({ type, radius: radius * 2 }),
+      });
+      expect(fn(circle)).toEqual({ type: 'circle', radius: 10 });
+    });
+
+    it('should pass through unmatched variant (same reference)', () => {
+      const fn = shapeOps.map({
+        circle: ({ type, radius }) => ({ type, radius: radius * 2 }),
+      });
+      expect(fn(rectangle)).toBe(rectangle);
+    });
+
+    it('should throw for invalid input', () => {
+      const fn = shapeOps.map({});
+      expect(() => fn(null as any)).toThrow(
+        'Data is not of type discriminated union!',
+      );
+    });
+  });
+
+  describe('mapAll', () => {
+    it('should transform all variants correctly', () => {
+      const fn = shapeOps.mapAll({
+        circle: ({ type, radius }) => ({ type, radius: radius * 2 }),
+        rectangle: ({ type, width, height }) => ({
+          type,
+          width: width * 2,
+          height: height * 2,
+        }),
+        triangle: ({ type, base, height }) => ({
+          type,
+          base: base * 2,
+          height: height * 2,
+        }),
+      });
+      expect(fn(circle)).toEqual({ type: 'circle', radius: 10 });
+      expect(fn(rectangle)).toEqual({
+        type: 'rectangle',
+        width: 8,
+        height: 12,
+      });
+      expect(fn(triangle)).toEqual({ type: 'triangle', base: 20, height: 6 });
+    });
+
+    it('should throw for invalid input', () => {
+      const fn = shapeOps.mapAll({
+        circle: (s) => s,
+        rectangle: (s) => s,
+        triangle: (s) => s,
+      });
+      expect(() => fn(null as any)).toThrow(
+        'Data is not of type discriminated union!',
+      );
+    });
+  });
+
+  describe('custom discriminant', () => {
+    it('match: should work with kind discriminant', () => {
+      const fn = animalOps.match({
+        dog: ({ name }) => `Dog: ${name}`,
+        cat: ({ lives }) => `Cat: ${lives} lives`,
+        bird: ({ canFly }) => `Bird: ${canFly ? 'can fly' : 'cannot fly'}`,
+      });
+      expect(fn(dog)).toBe('Dog: Rex');
+      expect(fn(cat)).toBe('Cat: 9 lives');
+      expect(fn(bird)).toBe('Bird: can fly');
+    });
+
+    it('matchWithDefault: should fall back to Default with kind discriminant', () => {
+      const fn = animalOps.matchWithDefault({
+        dog: ({ name }) => `Dog: ${name}`,
+        Default: () => 'Unknown',
+      });
+      expect(fn(dog)).toBe('Dog: Rex');
+      expect(fn(cat)).toBe('Unknown');
+    });
+
+    it('map: should transform and pass through with kind discriminant', () => {
+      const fn = animalOps.map({
+        cat: ({ kind, lives }) => ({ kind, lives: lives - 1 }),
+      });
+      expect(fn(cat)).toEqual({ kind: 'cat', lives: 8 });
+      expect(fn(dog)).toBe(dog);
+    });
+
+    it('mapAll: should transform all variants with kind discriminant', () => {
+      const fn = animalOps.mapAll({
+        dog: ({ kind, name }) => ({ kind, name: name.toUpperCase() }),
+        cat: ({ kind, lives }) => ({ kind, lives: lives + 1 }),
+        bird: ({ kind, canFly }) => ({ kind, canFly: !canFly }),
+      });
+      expect(fn(dog)).toEqual({ kind: 'dog', name: 'REX' });
+      expect(fn(cat)).toEqual({ kind: 'cat', lives: 10 });
+      expect(fn(bird)).toEqual({ kind: 'bird', canFly: false });
+    });
+  });
+
+  describe('reusability', () => {
+    it('handlers-first fn can be applied to many values independently', () => {
+      const describe = shapeOps.matchWithDefault({
+        circle: ({ radius }) => `circle(r=${radius})`,
+        Default: () => 'other',
+      });
+      expect(describe(circle)).toBe('circle(r=5)');
+      expect(describe(rectangle)).toBe('other');
+      expect(describe(triangle)).toBe('other');
+    });
+
+    it('two independent createPipeHandlers instances do not share state', () => {
+      const ops1 = createPipeHandlers<Shape, 'type'>('type');
+      const ops2 = createPipeHandlers<Shape, 'type'>('type');
+      const fn1 = ops1.match({
+        circle: () => 'ops1',
+        rectangle: () => 'ops1',
+        triangle: () => 'ops1',
+      });
+      const fn2 = ops2.match({
+        circle: () => 'ops2',
+        rectangle: () => 'ops2',
+        triangle: () => 'ops2',
+      });
+      expect(fn1(circle)).toBe('ops1');
+      expect(fn2(circle)).toBe('ops2');
+    });
+
+    it('map with empty handlers passes all variants through (same reference)', () => {
+      const fn = shapeOps.map({});
+      expect(fn(circle)).toBe(circle);
+      expect(fn(rectangle)).toBe(rectangle);
+      expect(fn(triangle)).toBe(triangle);
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 import { Model } from './types';
-export { match, matchWithDefault, map, mapAll } from './unions';
+export {
+  match,
+  matchWithDefault,
+  map,
+  mapAll,
+  createPipeHandlers,
+} from './unions';
 export { is, isUnion } from './module';
-export type { Model } from './types';
+export type { Model, TakeDiscriminant } from './types';
 
 /**
  * Utility type that extracts a discriminated union from an array of {@link Model} types.

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,43 +1,22 @@
-import { is, map, mapAll, match, matchWithDefault, UnionByArray } from '.';
+// import { pipe } from 'fp-ts/lib/function';
+import { createPipeHandlers } from '.';
 
-type A = { type: 'A'; a: number };
-type B = { type: 'B'; b: string };
-type C = { type: 'C'; c: boolean };
+type A = { kind: 'A'; a: number };
+type B = { kind: 'B'; b: string };
+type C = { kind: 'C'; c: boolean };
 
-type Model = UnionByArray<[A, B, C]>;
+type Model = A | B | C;
 
 const x: Model = {} as any;
 
-// Enforces exhaustiveness
-match(x)<boolean>({
-  A: (a) => a.a > 20,
-  B: (b) => b.b.length > 5,
-  C: (c) => c.c,
-});
+const { map, mapAll, match, matchWithDefault } =
+  createPipeHandlers<Model>('kind');
 
-matchWithDefault(x)({
-  A: (a) => {
-    console.log('A');
-  },
-  B: (b) => console.log('B'),
-  Default: () => {
-    console.log('Default functionality');
-  },
-});
-
-const updateddX = map(x)({
-  A: (a) => ({ ...a, a: 1 }),
-  B: (b) => ({ ...b, b: 'new B' }),
-  C: (c) => ({ ...c, c: false }),
-});
-
-// Enforces exhaustiveness
-const updatedX = mapAll(x)({
-  A: (a) => ({ ...a, a: 1 }),
-  B: (b) => ({ ...b, b: 'new B' }),
-  C: (c) => ({ ...c, c: false }),
-});
-
-if (is(x, 'A')) {
-  console.log(x.a);
-}
+// const result = pipe(
+//   x,
+//   match({
+//     A: (a) => a.a,
+//     B: (b) => b.b.length,
+//     C: (c) => (c.c ? 1 : 0),
+//   }),
+// );

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,8 +33,8 @@ export type SampleUnion<Discriminant extends string | number | symbol> = {
  */
 export type Model<
   DiscriminantValue extends string,
-  Data,
-  Discriminant extends string | number | symbol,
+  Data = {},
+  Discriminant extends string | number | symbol = 'type',
 > = {
   [K in Discriminant]: DiscriminantValue;
 } & Data;


### PR DESCRIPTION
…docs

Features:
- Add createPipeHandlers<T, Discriminant>(discriminant) for pipe-friendly handlers-first currying: (handlers) => (input) => result
- Export createPipeHandlers and TakeDiscriminant from the public API
- Model<> now defaults Data to {} and Discriminant to 'type', enabling the common 1- and 2-arg forms (Model<'idle'>, Model<'ok', { data: T }>)

Samples (education only, excluded from bundle):
- samples/fetch-state.ts — async state machine with all four states
- samples/pipe-composition.ts — createPipeHandlers in a data pipeline
- samples/notifications.ts — notification centre with map/is/match
- samples/tsconfig.json — resolves 'dismatch' to local source for IDE support

Tests (91 total, all passing):
- Add missing variant coverage: triangle in mapAll, bird in custom-discriminant mapAll
- Add reusability tests: handlers-first fn applied to many values, two isolated instances
- Add empty-mapper pass-through test for createPipeHandlers.map
- Add array filtering tests for is() in module.test.ts
- Clean up verbose type annotations in createPipeHandlers shapeMatcher

Docs:
- Full README restructure: TOC, API reference with correct type-safe examples, createPipeHandlers pipe-composition guide, type helper docs, real-world patterns
- Fix map/mapAll handler examples to correctly exclude discriminant from parameter destructuring (type: 'variant' as const in the return instead)