### PR TITLE
Default handler has (input:T) type + New collection-ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - `MatcherWithDefault.Default` and `AsyncMatcherWithDefault.Default` type signatures updated — `Default` is declared as `(item: T, ...payload) => Result` using the rest-parameter form, which avoids the deferred-conditional-type problem and enables full contextual typing of `item`.
+- **`GroupByResult` keys are now optional** — absent variant groups were already absent at runtime; the type now reflects this. Callers accessing `groups.circle` must guard with `groups.circle?.` or a length/existence check.
 
 ### Documentation
 
@@ -25,7 +26,7 @@
 
 - **`find(items, variants, discriminant?)`** — returns the first item matching the given variant(s), narrowed to that type, or `undefined`. Non-union items silently skipped.
 - **`some(items, variants, discriminant?)`** — returns `true` if any item matches the given variant(s). Supports single and multi-variant. Non-union items silently skipped.
-- **`every(items, variants, discriminant?)`** — returns `true` if every item matches the given variant(s). Returns `true` for empty collections (vacuous truth). Non-union items silently skipped.
+- **`every(items, variants, discriminant?)`** — returns `true` if every item matches the given variant(s). Non-union items are silently skipped; a collection of only non-union items is treated as empty and also returns `true` (vacuous truth, consistent with `Array.prototype.every`).
 - **`groupBy(items, discriminant?)`** — groups a collection by variant in one pass. Each group is narrowed to the specific variant type (`{ circle: Circle[]; rectangle: Rectangle[] }`). Non-union items silently skipped.
 - **`filterMap(items, handlers, discriminant?)`** — filters and transforms in one pass. Handler returns a value to keep or `undefined` to skip. `null` is a valid kept value. Unhandled variants silently skipped. Non-union items silently skipped.
 - All five ops available as standalone functions and as pipe-friendly bindings on `createPipeHandlers` and `createUnion`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,21 @@
 
 ## [2.6.0] - 2026-05-16
 
-### Changed
+### Breaking
 
 - **`matchWithDefault` and `matchWithDefaultAsync` — `Default` now receives the triggering item** — `Default` is called with the full union value as its first argument (`item: T`), giving callers access to both the discriminant and any data fields. Previously `Default` received no arguments. `Default: () => fallback` (no declared parameters) continues to compile and work without change — TypeScript allows ignoring declared parameters.
-- **Payload callers: `Default` signature shifted** — when a `Payload` generic is in use, `Default` now receives `(item, payload)` instead of `(payload)`. This is a breaking change for the small subset of callers that pass a payload and handle `Default`.
+- **Payload callers: `Default` signature shifted** — when a `Payload` generic is in use, `Default` now receives `(item, payload)` instead of `(payload)`. This affects callers that pass a payload and handle `Default`.
+- **New bound collection operation names are reserved in `createUnion` schemas** — `find`, `some`, `every`, `groupBy`, and `filterMap` now join the reserved factory keys. Schemas using those names as variants must rename the variant or use standalone collection helpers with plain union values.
+- **`GroupByResult` keys are now optional** — absent variant groups were already absent at runtime; the type now reflects this. Callers accessing `groups.circle` must guard with `groups.circle?.`, `groups.circle ?? []`, or an existence check.
+
+### Changed
+
 - **Build target bumped to `es2022`** — `tsup.config.ts` now targets ES2022 (was ES2020), enabling native output for features like class static blocks and `at()`.
 
 ### Fixed
 
 - `MatcherWithDefault.Default` and `AsyncMatcherWithDefault.Default` type signatures updated — `Default` is declared as `(item: T, ...payload) => Result` using the rest-parameter form, which avoids the deferred-conditional-type problem and enables full contextual typing of `item`.
-- **`GroupByResult` keys are now optional** — absent variant groups were already absent at runtime; the type now reflects this. Callers accessing `groups.circle` must guard with `groups.circle?.` or a length/existence check.
+- Bound `createUnion(...).groupBy(...)` now returns the same optional-keyed `GroupByResult` type as standalone `groupBy(...)` and `createPipeHandlers(...).groupBy(...)`.
 
 ### Documentation
 
@@ -27,7 +32,7 @@
 - **`find(items, variants, discriminant?)`** — returns the first item matching the given variant(s), narrowed to that type, or `undefined`. Non-union items silently skipped.
 - **`some(items, variants, discriminant?)`** — returns `true` if any item matches the given variant(s). Supports single and multi-variant. Non-union items silently skipped.
 - **`every(items, variants, discriminant?)`** — returns `true` if every item matches the given variant(s). Non-union items are silently skipped; a collection of only non-union items is treated as empty and also returns `true` (vacuous truth, consistent with `Array.prototype.every`).
-- **`groupBy(items, discriminant?)`** — groups a collection by variant in one pass. Each group is narrowed to the specific variant type (`{ circle: Circle[]; rectangle: Rectangle[] }`). Non-union items silently skipped.
+- **`groupBy(items, discriminant?)`** — groups a collection by variant in one pass. Each present group is narrowed to the specific variant type (`{ circle?: Circle[]; rectangle?: Rectangle[] }`). Non-union items silently skipped.
 - **`filterMap(items, handlers, discriminant?)`** — filters and transforms in one pass. Handler returns a value to keep or `undefined` to skip. `null` is a valid kept value. Unhandled variants silently skipped. Non-union items silently skipped.
 - All five ops available as standalone functions and as pipe-friendly bindings on `createPipeHandlers` and `createUnion`.
 - New exported types: `FilterMapHandlers<T, Result, Discriminant>`, `GroupByResult<T, Discriminant>`.
@@ -49,7 +54,7 @@
 
 - `MatcherWithDefault.Default`, `Mapper`, and `MapperAll` payload signatures no longer force a synthetic `payload` parameter when `Payload` is omitted — their type-level call shapes now match the runtime curried APIs.
 - README fully restructured around reusable handlers, async matching, runtime errors, and bundle-size positioning; added dedicated sections for the async surface and `UnknownVariantError`.
-- **Package verification updated for the expanded public surface** — `verify-package.mjs` now expects the async exports and `UnknownVariantError` from the main entry while continuing to assert that `dismatch/remote-data` exports *exactly* `['RemoteData']`.
+- **Package verification updated for the expanded public surface** — `verify-package.mjs` now expects the async exports and `UnknownVariantError` from the main entry while continuing to assert that `dismatch/remote-data` exports _exactly_ `['RemoteData']`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,38 @@
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-05-16
+
 ### Changed
 
+- **`matchWithDefault` and `matchWithDefaultAsync` — `Default` now receives the triggering item** — `Default` is called with the full union value as its first argument (`item: T`), giving callers access to both the discriminant and any data fields. Previously `Default` received no arguments. `Default: () => fallback` (no declared parameters) continues to compile and work without change — TypeScript allows ignoring declared parameters.
+- **Payload callers: `Default` signature shifted** — when a `Payload` generic is in use, `Default` now receives `(item, payload)` instead of `(payload)`. This is a breaking change for the small subset of callers that pass a payload and handle `Default`.
 - **Build target bumped to `es2022`** — `tsup.config.ts` now targets ES2022 (was ES2020), enabling native output for features like class static blocks and `at()`.
+
+### Fixed
+
+- `MatcherWithDefault.Default` and `AsyncMatcherWithDefault.Default` type signatures updated — `Default` is declared as `(item: T, ...payload) => Result` using the rest-parameter form, which avoids the deferred-conditional-type problem and enables full contextual typing of `item`.
+
+### Documentation
+
+- **Featured plain-object emission as a top-of-README strength** — `createUnion` produces plain `{ type, ... }` objects with no runtime wrappers, enabling wire serialization, clean debugging, and direct interop with `switch` / `ts-pattern`.
+- **Quick Start now documents two re-export idioms** — "namespace style" (factory + `InferUnion`) and "exit-friendly style" (file-private factory; type alias derived from `ReturnType` of constructors so it has no dependency on the factory).
+- **New `Removing dismatch` section** — mechanical rewrite recipe (constructor → object literal, `match(...)` → `switch`, `is(...)` → `===`) plus an incremental-adoption block showing the same value matched with `switch`, `ts-pattern`, and dismatch side-by-side.
+- **Comparison table extended** — added `Adoption & interop` group with rows for plain-object output and source-level exit cost.
+
+### Added
+
+- **`find(items, variants, discriminant?)`** — returns the first item matching the given variant(s), narrowed to that type, or `undefined`. Non-union items silently skipped.
+- **`some(items, variants, discriminant?)`** — returns `true` if any item matches the given variant(s). Supports single and multi-variant. Non-union items silently skipped.
+- **`every(items, variants, discriminant?)`** — returns `true` if every item matches the given variant(s). Returns `true` for empty collections (vacuous truth). Non-union items silently skipped.
+- **`groupBy(items, discriminant?)`** — groups a collection by variant in one pass. Each group is narrowed to the specific variant type (`{ circle: Circle[]; rectangle: Rectangle[] }`). Non-union items silently skipped.
+- **`filterMap(items, handlers, discriminant?)`** — filters and transforms in one pass. Handler returns a value to keep or `undefined` to skip. `null` is a valid kept value. Unhandled variants silently skipped. Non-union items silently skipped.
+- All five ops available as standalone functions and as pipe-friendly bindings on `createPipeHandlers` and `createUnion`.
+- New exported types: `FilterMapHandlers<T, Result, Discriminant>`, `GroupByResult<T, Discriminant>`.
+
+### Bundle size
+
+- Canonical metric (`esbuild --bundle --minify`, non-gzipped): **3,250 B (3.17 KB)** — +805 B from 2.5.0, adding five new collection operations (~161 B/op). Stays under the 4.0 KB cap.
 
 ## [2.5.0] - 2026-04-26
 

--- a/README.md
+++ b/README.md
@@ -661,8 +661,8 @@ Groups a collection by variant in one pass. Each group is narrowed to the specif
 import { groupBy } from 'dismatch';
 
 const groups = groupBy(shapes);
-groups.circle;     // Circle[]
-groups.rectangle;  // Rectangle[]
+groups.circle;     // Circle[] | undefined
+groups.rectangle;  // Rectangle[] | undefined
 
 // Custom discriminant
 groupBy(events, 'kind');
@@ -823,7 +823,7 @@ const summary = await foldWithDefaultAsync(
 
 ## Pipe Composition
 
-`createPipeHandlers` returns the same set of sync operations in **handlers-first** curried order — you define handlers once, get back a reusable function bound to the union type and discriminant. No generics needed at call sites. Exposes `match`, `matchWithDefault`, `map`, `mapAll`, `fold`, `foldWithDefault`, `count`, `partition`, and `is`. (Async helpers are standalone-only — see [Async Functions](#async-functions).)
+`createPipeHandlers` returns the same set of sync operations in **handlers-first** curried order — you define handlers once, get back a reusable function bound to the union type and discriminant. No generics needed at call sites. Exposes `match`, `matchWithDefault`, `map`, `mapAll`, `fold`, `foldWithDefault`, `count`, `partition`, `find`, `some`, `every`, `groupBy`, `filterMap`, and `is`. (Async helpers are standalone-only — see [Async Functions](#async-functions).)
 
 ```ts
 import { createPipeHandlers } from 'dismatch';

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/dismatch)](https://bundlephobia.com/package/dismatch)
 
-Type-safe discriminated unions for TypeScript. Define once, get constructors, type guards, exhaustive pattern matching, async dispatch, and runtime validation — all from a single schema. Zero dependencies. ~1.1 kB gzipped.
+Type-safe discriminated unions for TypeScript. Define once, get constructors, type guards, exhaustive pattern matching, async dispatch, and runtime validation — all from a single schema. Zero dependencies. ~1.5 kB gzipped.
 
 ```ts
 import { createUnion, is, type InferUnion } from 'dismatch';
@@ -28,6 +28,8 @@ const area = Shape.match({
 
 area(Shape.circle(5)); // 78.54
 ```
+
+> **No runtime wrappers** — `createUnion` produces plain objects, so values cross network boundaries, debug cleanly, and interop with `switch` / `ts-pattern` without unwrapping. See [Removing dismatch](#removing-dismatch) for the exit path.
 
 > **`switch` gives you exhaustiveness. `dismatch` gives you exhaustiveness plus reusable typed matchers, `map`, `fold`, `partition`, `count`, `is`, runtime validation, and async — all from a single schema.**
 
@@ -137,6 +139,7 @@ npm install dismatch
 - [Type Helpers](#type-helpers)
 - [Custom Discriminant](#custom-discriminant)
 - [Patterns](#patterns)
+- [Removing dismatch](#removing-dismatch)
 - [RemoteData](#remotedata)
 - [Runtime Errors & Clean Stack Traces](#runtime-errors--clean-stack-traces)
 - [Contributing](#contributing)
@@ -148,40 +151,47 @@ npm install dismatch
 
 > **`ts-pattern` matches any pattern. `dismatch` manages discriminated unions — and is the only one with first-class async.**
 
-| Capability                                          |          dismatch          |      ts-pattern       | unionize  |    @effect/match     |
-| --------------------------------------------------- | :------------------------: | :-------------------: | :-------: | :------------------: |
-| **Footprint**                                       |                            |                       |           |                      |
-| Size, minified (full main entry, not gzipped)       |        **~2.4 kB**         |        ~7.7 kB        | unclear   |    ecosystem-tied    |
-| Zero dependencies                                   |             ✓              |           ✓           |     ✓     |          ✗           |
-| Per-function tree-shaking                           |             ✓              |        partial        |     —     |       partial        |
-| Active maintenance                                  |             ✓              |           ✓           | ✗ (2018)  |          ✓           |
-| **Compile-time correctness**                        |                            |                       |           |                      |
-| Exhaustive matching for DUs                         |             ✓              | ✓ via `.exhaustive()` |     ✓     |          ✓           |
-| No `{ type: '…' }` / `.with()` ceremony per branch  |             ✓              |           ✗           |     ✓     |          ✗           |
-| Reusable, curried handlers (define once, reuse)     |             ✓              |     ✗ (one-shot)      |     ✓     |       partial        |
-| Sub-union narrowing on `.filter()` / `.find()`      |             ✓              |           ✗           |     ✗     |          ✗           |
-| Payload threaded through every handler              |             ✓              |           ✗           |     ✗     |          ✗           |
-| **Async — unique to dismatch**                      |                            |                       |           |                      |
-| `matchAsync` — single value, unified `Promise<R>`   |           **✓**            |           ✗           |     ✗     |          ✗           |
-| `matchWithDefaultAsync` — partial async             |           **✓**            |           ✗           |     ✗     |          ✗           |
-| `matchAllAsync` — parallel, order-preserved         |           **✓**            |           ✗           |     ✗     |          ✗           |
-| `foldAsync` — sequential aggregation                |           **✓**            |           ✗           |     ✗     |          ✗           |
-| `foldWithDefaultAsync`                              |           **✓**            |           ✗           |     ✗     |          ✗           |
-| `mapAsync` — async partial transform                |           **✓**            |           ✗           |     ✗     |          ✗           |
-| Mixed sync + async handlers still unify             |           **✓**            |           ✗           |     ✗     |          ✗           |
-| **Variant-aware collections**                       |                            |                       |           |                      |
-| `fold` — exhaustive single-pass aggregation         |             ✓              |           ✗           |     ✗     |          ✗           |
-| `foldWithDefault` — partial aggregation             |             ✓              |           ✗           |     ✗     |          ✗           |
-| `count` by variant(s)                               |             ✓              |           ✗           |     ✗     |          ✗           |
-| `partition` (both sides narrowed)                   |             ✓              |           ✗           |     ✗     |          ✗           |
-| `map` partial transform (discriminant kept)         |             ✓              |           ✗           |     ✗     |          ✗           |
-| `mapAll` exhaustive transform                       |             ✓              |           ✗           |     ✗     |          ✗           |
-| **Runtime & schema**                                |                            |                       |           |                      |
-| `createUnion` — one schema, full toolkit            |             ✓              |           ✗           | ✓ (stale) |          ✗           |
-| `isKnown` — schema-membership check                 |             ✓              |           ✗           |     ✗     | via `@effect/schema` |
-| Named `UnknownVariantError` (`.variant`, `.known`)  |             ✓              |           ✗           |     ✗     |          ✗           |
-| Clean stack traces (point at your call site)        |             ✓              |           ✗           |     ✗     |          ✗           |
-| Companion async-state union (`dismatch/remote-data`)|             ✓              |           ✗           |     ✗     |          ✗           |
+| Capability                                           |     dismatch     |      ts-pattern       | unionize  |    @effect/match     |
+| ---------------------------------------------------- | :--------------: | :-------------------: | :-------: | :------------------: |
+| **Footprint**                                        |                  |                       |           |                      |
+| Size, minified (full main entry, not gzipped)        |   **~3.2 kB**    |        ~7.7 kB        |  unclear  |    ecosystem-tied    |
+| Zero dependencies                                    |        ✓         |           ✓           |     ✓     |          ✗           |
+| Per-function tree-shaking                            |        ✓         |        partial        |     —     |       partial        |
+| Active maintenance                                   |        ✓         |           ✓           | ✗ (2018)  |          ✓           |
+| **Adoption & interop**                               |                  |                       |           |                      |
+| Plain-object output (wire-serializable, no wrappers) |        ✓         |          N/A          |     ✓     |          ✗           |
+| Source-level exit cost                               | low (mechanical) |          N/A          |    low    |         high         |
+| **Compile-time correctness**                         |                  |                       |           |                      |
+| Exhaustive matching for DUs                          |        ✓         | ✓ via `.exhaustive()` |     ✓     |          ✓           |
+| No `{ type: '…' }` / `.with()` ceremony per branch   |        ✓         |           ✗           |     ✓     |          ✗           |
+| Reusable, curried handlers (define once, reuse)      |        ✓         |     ✗ (one-shot)      |     ✓     |       partial        |
+| Sub-union narrowing on `.filter()` / `.find()`       |        ✓         |           ✗           |     ✗     |          ✗           |
+| Payload threaded through every handler               |        ✓         |           ✗           |     ✗     |          ✗           |
+| **Async — unique to dismatch**                       |                  |                       |           |                      |
+| `matchAsync` — single value, unified `Promise<R>`    |      **✓**       |           ✗           |     ✗     |          ✗           |
+| `matchWithDefaultAsync` — partial async              |      **✓**       |           ✗           |     ✗     |          ✗           |
+| `matchAllAsync` — parallel, order-preserved          |      **✓**       |           ✗           |     ✗     |          ✗           |
+| `foldAsync` — sequential aggregation                 |      **✓**       |           ✗           |     ✗     |          ✗           |
+| `foldWithDefaultAsync`                               |      **✓**       |           ✗           |     ✗     |          ✗           |
+| `mapAsync` — async partial transform                 |      **✓**       |           ✗           |     ✗     |          ✗           |
+| Mixed sync + async handlers still unify              |      **✓**       |           ✗           |     ✗     |          ✗           |
+| **Variant-aware collections**                        |                  |                       |           |                      |
+| `fold` — exhaustive single-pass aggregation          |        ✓         |           ✗           |     ✗     |          ✗           |
+| `foldWithDefault` — partial aggregation              |        ✓         |           ✗           |     ✗     |          ✗           |
+| `count` by variant(s)                                |        ✓         |           ✗           |     ✗     |          ✗           |
+| `partition` (both sides narrowed)                    |        ✓         |           ✗           |     ✗     |          ✗           |
+| `find` — first match, narrowed                       |        ✓         |           ✗           |     ✗     |          ✗           |
+| `some` / `every` — boolean predicates                |        ✓         |           ✗           |     ✗     |          ✗           |
+| `groupBy` — all groups, narrowed types               |        ✓         |           ✗           |     ✗     |          ✗           |
+| `filterMap` — filter + transform in one pass         |        ✓         |           ✗           |     ✗     |          ✗           |
+| `map` partial transform (discriminant kept)          |        ✓         |           ✗           |     ✗     |          ✗           |
+| `mapAll` exhaustive transform                        |        ✓         |           ✗           |     ✗     |          ✗           |
+| **Runtime & schema**                                 |                  |                       |           |                      |
+| `createUnion` — one schema, full toolkit             |        ✓         |           ✗           | ✓ (stale) |          ✗           |
+| `isKnown` — schema-membership check                  |        ✓         |           ✗           |     ✗     | via `@effect/schema` |
+| Named `UnknownVariantError` (`.variant`, `.known`)   |        ✓         |           ✗           |     ✗     |          ✗           |
+| Clean stack traces (point at your call site)         |        ✓         |           ✗           |     ✗     |          ✗           |
+| Companion async-state union (`dismatch/remote-data`) |        ✓         |           ✗           |     ✗     |          ✗           |
 
 > **Need regex, wildcards, nested object patterns, or class-instance matching?** Use `ts-pattern` — those aren't DU problems. For the 90% of TypeScript code where unions look like `{ type: 'x' } | { type: 'y' }`, `dismatch` is the scalpel.
 
@@ -224,6 +234,46 @@ const Event = createUnion('kind', {
 type Event = InferUnion<typeof Event>;
 // { kind: 'click'; x: number } | { kind: 'key'; code: string }
 ```
+
+#### Re-exporting constructors
+
+`createUnion` returns a plain object holding constructors, matchers, and metadata, so you can destructure and re-export anything you want. Two idioms cover the common cases.
+
+**Namespace style** — keep the factory public, destructure for ergonomics:
+
+```ts
+// shape.ts
+export const Shape = createUnion({
+  circle: (radius: number) => ({ radius }),
+  rectangle: (width: number, height: number) => ({ width, height }),
+});
+export type Shape = InferUnion<typeof Shape>;
+export const { circle, rectangle } = Shape;
+
+// consumer.ts
+import { Shape, circle } from './shape';
+const c = circle(5);
+const area = Shape.match({
+  /* ... */
+});
+```
+
+**Exit-friendly style** — keep the factory file-private; only constructors and the type leave the module. Type alias derives from `ReturnType` of the constructors, so it has no dependency on the factory:
+
+```ts
+// shape.ts
+const _Shape = createUnion({
+  circle: (radius: number) => ({ radius }),
+  rectangle: (width: number, height: number) => ({ width, height }),
+});
+export const { circle, rectangle, match, matchWithDefault, is } = _Shape;
+export type Shape = ReturnType<typeof circle> | ReturnType<typeof rectangle>;
+
+// consumer.ts
+import { circle, match, type Shape } from './shape';
+```
+
+The exit-friendly style is what makes [Removing dismatch](#removing-dismatch) mechanical: the type alias survives even after the factory is gone, because it's a TS-native discriminated union.
 
 ### 2. Construct values
 
@@ -561,6 +611,86 @@ const [actionable, rest] = partition(notifications, ['NEW', 'ACTION_NEEDED']);
 const [clicks, others] = partition(events, 'click', 'kind');
 ```
 
+### `find`
+
+Returns the first item in a collection matching the given variant(s), narrowed to that type, or `undefined`. Non-union items are silently skipped.
+
+```ts
+import { find } from 'dismatch';
+
+find(shapes, 'circle');                    // Circle | undefined
+find(shapes, ['circle', 'rectangle']);     // Circle | Rectangle | undefined
+
+// Custom discriminant
+find(events, 'click', 'kind');
+```
+
+### `some`
+
+Returns `true` if any item in the collection matches the given variant(s). Non-union items are silently skipped.
+
+```ts
+import { some } from 'dismatch';
+
+some(shapes, 'circle');                    // boolean
+some(shapes, ['circle', 'rectangle']);     // boolean
+
+// Custom discriminant
+some(events, 'click', 'kind');
+```
+
+### `every`
+
+Returns `true` if every item in the collection matches the given variant(s). Non-union items are silently skipped. Returns `true` for an empty collection (vacuous truth, consistent with `Array.prototype.every`).
+
+```ts
+import { every } from 'dismatch';
+
+every(shapes, 'circle');                   // true only if all shapes are circles
+every(shapes, ['circle', 'rectangle']);    // true if no triangles
+
+// Custom discriminant
+every(events, 'click', 'kind');
+```
+
+### `groupBy`
+
+Groups a collection by variant in one pass. Each group is narrowed to the specific variant type. Keys for variants absent from the input are not present in the result.
+
+```ts
+import { groupBy } from 'dismatch';
+
+const groups = groupBy(shapes);
+groups.circle;     // Circle[]
+groups.rectangle;  // Rectangle[]
+
+// Custom discriminant
+groupBy(events, 'kind');
+```
+
+### `filterMap`
+
+Filters and transforms a collection in one pass. Each handler returns a transformed value to keep, or `undefined` to skip. Variants with no handler are silently skipped. `null` is a valid kept value.
+
+```ts
+import { filterMap } from 'dismatch';
+
+const areas = filterMap(shapes, {
+  circle: ({ radius }) => Math.PI * radius ** 2,
+  // rectangle and triangle omitted — silently skipped
+});
+// areas: number[]
+
+// Return undefined to conditionally skip within a handler
+const largeAreas = filterMap(shapes, {
+  circle: ({ radius }) => radius > 10 ? Math.PI * radius ** 2 : undefined,
+  rectangle: ({ width, height }) => width * height > 50 ? width * height : undefined,
+});
+
+// Custom discriminant
+filterMap(events, { click: ({ x, y }) => `${x},${y}` }, 'kind');
+```
+
 ### `isUnion`
 
 Runtime check that a value is a valid discriminated union.
@@ -680,7 +810,10 @@ Partial async fold with an async-or-sync `Default` fallback. Sequential — accu
 ```ts
 import { foldWithDefaultAsync } from 'dismatch/async';
 
-const summary = await foldWithDefaultAsync(events, '')({
+const summary = await foldWithDefaultAsync(
+  events,
+  '',
+)({
   click: async (acc, { x }) => `${acc} click@${await label(x)}`,
   Default: (acc) => acc,
 });
@@ -860,6 +993,92 @@ const reduce = (state: number, action: Action): number =>
     reset: () => 0,
   });
 ```
+
+---
+
+## Removing dismatch
+
+Lock-in is a fair concern when a library shows up at hundreds of call sites. `dismatch` is designed so removal is mechanical, not redesign:
+
+- **Values are plain objects** — `circle(5)` returns `{ type: 'circle', radius: 5 }`. Nothing to unwrap.
+- **Types are TS-native discriminated unions** — if you used the [exit-friendly style](#re-exporting-constructors), the type alias has no dependency on `dismatch` at all.
+- **Matchers are exhaustive `switch` in disguise** — TypeScript already enforces exhaustiveness on `switch` over discriminated unions.
+
+### Mechanical rewrite
+
+Starting from this `dismatch` code:
+
+```ts
+import { createUnion, type InferUnion } from 'dismatch';
+
+const _Result = createUnion({
+  ok: (data: string) => ({ data }),
+  err: (message: string) => ({ message }),
+});
+export const { ok, err, match, is } = _Result;
+export type Result = ReturnType<typeof ok> | ReturnType<typeof err>;
+
+// call sites
+const r = ok('hi');
+const banner = match({
+  ok: ({ data }) => `Loaded: ${data}`,
+  err: ({ message }) => `Error: ${message}`,
+});
+if (is('ok')(r)) r.data;
+```
+
+Replace constructors with object literals, matchers with `switch`, and `is(...)` with `===`. The `Result` type alias does not change:
+
+```ts
+export const ok = (data: string) => ({ type: 'ok' as const, data });
+export const err = (message: string) => ({ type: 'err' as const, message });
+export type Result = ReturnType<typeof ok> | ReturnType<typeof err>;
+
+const banner = (r: Result) => {
+  switch (r.type) {
+    case 'ok':
+      return `Loaded: ${r.data}`;
+    case 'err':
+      return `Error: ${r.message}`;
+  }
+};
+const r = ok('hi');
+if (r.type === 'ok') r.data;
+```
+
+The constructor-call shape (`ok('hi')`) is unchanged at every call site — only the constructor _definition_ file is touched. Matcher rewrites are local to wherever you called `match(...)`.
+
+### Incremental adoption — you don't have to leave to mix tools
+
+Because output is plain `{ type, ... }`, dismatch values feed any other matcher unchanged. Use whichever tool fits the call site:
+
+```ts
+import { match as tsPatternMatch } from 'ts-pattern';
+
+const r = ok('hi'); // dismatch constructor
+
+// Plain switch — zero dependencies
+switch (r.type) {
+  case 'ok':
+    /* ... */ break;
+  case 'err':
+    /* ... */ break;
+}
+
+// ts-pattern — for nested patterns, regex, wildcards
+const label = tsPatternMatch(r)
+  .with({ type: 'ok' }, ({ data }) => data)
+  .with({ type: 'err' }, ({ message }) => message)
+  .exhaustive();
+
+// dismatch — for reusable typed matchers
+const banner = match({
+  ok: ({ data }) => `Loaded: ${data}`,
+  err: ({ message }) => `Error: ${message}`,
+});
+```
+
+You can adopt `createUnion` for value generation today and reach for `ts-pattern` (or a plain `switch`) wherever its strengths matter — no conversion layer, no wrapping, no factory dependency at the matcher.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dismatch",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dismatch",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dismatch",
   "description": "A lightweight discriminated unions library for TypeScript",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",

--- a/samples/collection-ops.ts
+++ b/samples/collection-ops.ts
@@ -1,0 +1,90 @@
+/**
+ * Collection Operations
+ *
+ * Demonstrates the complete collection family: find, some, every, groupBy, filterMap.
+ * All ops are single-pass, allocation-conscious, and variant-aware.
+ */
+
+import { find, some, every, groupBy, filterMap } from 'dismatch';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+type Task =
+  | { type: 'todo'; title: string; priority: 'low' | 'high' }
+  | { type: 'in_progress'; title: string; assignee: string }
+  | { type: 'done'; title: string; completedAt: Date }
+  | { type: 'blocked'; title: string; reason: string };
+
+// ── Sample data ────────────────────────────────────────────────────────────────
+
+const tasks: Task[] = [
+  { type: 'todo', title: 'Write tests', priority: 'high' },
+  { type: 'in_progress', title: 'Fix bug', assignee: 'alice' },
+  { type: 'todo', title: 'Update docs', priority: 'low' },
+  { type: 'done', title: 'Design review', completedAt: new Date('2026-05-01') },
+  { type: 'blocked', title: 'Deploy', reason: 'Waiting for approval' },
+  { type: 'in_progress', title: 'Code review', assignee: 'bob' },
+  { type: 'done', title: 'Planning', completedAt: new Date('2026-04-28') },
+];
+
+// ── find ───────────────────────────────────────────────────────────────────────
+
+// First blocked task, or undefined if none
+const firstBlocked = find(tasks, 'blocked');
+// ^ { type: 'blocked'; title: string; reason: string } | undefined
+
+// First actionable task (todo or in_progress)
+const firstActionable = find(tasks, ['todo', 'in_progress'] as const);
+// ^ { type: 'todo'; ... } | { type: 'in_progress'; ... } | undefined
+
+// ── some / every ───────────────────────────────────────────────────────────────
+
+// Is there work still in flight?
+const hasActiveWork = some(tasks, ['todo', 'in_progress'] as const); // true
+
+// Are all tasks resolved (done or blocked)?
+const allResolved = every(tasks, ['done', 'blocked'] as const); // false
+
+// Is there anything blocked right now?
+const hasBlocker = some(tasks, 'blocked'); // true
+
+// ── groupBy ────────────────────────────────────────────────────────────────────
+
+// All tasks grouped by status in one pass — each group is narrowed to its variant
+const groups = groupBy(tasks);
+
+const todoTasks = groups.todo;         // { type: 'todo'; title: string; priority: ... }[]
+const doneTasks = groups.done;         // { type: 'done'; title: string; completedAt: Date }[]
+const inProgress = groups.in_progress; // { type: 'in_progress'; title: string; assignee: string }[]
+
+// ── filterMap ──────────────────────────────────────────────────────────────────
+
+// Extract titles of high-priority todos only (filter + transform in one pass)
+const urgentTitles: string[] = filterMap(tasks, {
+  todo: ({ title, priority }) => priority === 'high' ? title : undefined,
+  // in_progress, done, blocked omitted — silently skipped
+});
+
+// Build a summary of active work with assignee info
+const activeSummaries: string[] = filterMap(tasks, {
+  todo: ({ title, priority }) => `[${priority.toUpperCase()}] ${title}`,
+  in_progress: ({ title, assignee }) => `${title} (${assignee})`,
+});
+
+// Collect completion timestamps — null is a valid result; undefined signals skip
+const completionDates: Date[] = filterMap(tasks, {
+  done: ({ completedAt }) => completedAt,
+});
+
+// Verify results
+firstBlocked;
+firstActionable;
+hasActiveWork;
+allResolved;
+hasBlocker;
+todoTasks;
+doneTasks;
+inProgress;
+urgentTitles;
+activeSummaries;
+completionDates;

--- a/samples/notifications.ts
+++ b/samples/notifications.ts
@@ -13,14 +13,33 @@
  *   - createPipeHandlers for reusable, array-friendly operations
  */
 
-import { match, matchWithDefault, map, mapAll, is, createPipeHandlers } from 'dismatch';
+import {
+  match,
+  matchWithDefault,
+  map,
+  mapAll,
+  is,
+  createPipeHandlers,
+} from 'dismatch';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
 type Notification =
-  | { type: 'email'; from: string; subject: string; read: boolean; starred: boolean }
-  | { type: 'sms';   from: string; body: string;    read: boolean }
-  | { type: 'push';  app: string;  title: string;   read: boolean; urgent: boolean };
+  | {
+      type: 'email';
+      from: string;
+      subject: string;
+      read: boolean;
+      starred: boolean;
+    }
+  | { type: 'sms'; from: string; body: string; read: boolean }
+  | {
+      type: 'push';
+      app: string;
+      title: string;
+      read: boolean;
+      urgent: boolean;
+    };
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -29,29 +48,29 @@ const notifOps = createPipeHandlers<Notification, 'type'>('type');
 /** Single-line preview text shown in the notification list. */
 const getPreview = notifOps.match({
   email: ({ from, subject }) => `📧 ${from}: ${subject}`,
-  sms:   ({ from, body })    => `💬 ${from}: ${body.slice(0, 60)}`,
-  push:  ({ app, title })    => `🔔 ${app}: ${title}`,
+  sms: ({ from, body }) => `💬 ${from}: ${body.slice(0, 60)}`,
+  push: ({ app, title }) => `🔔 ${app}: ${title}`,
 });
 
 /** Importance score — urgent push notes bubble to the top. */
 const getPriority = notifOps.match({
-  email: ({ starred }) => starred ? 2 : 1,
-  sms:   ()            => 1,
-  push:  ({ urgent })  => urgent ? 3 : 1,
+  email: ({ starred }) => (starred ? 2 : 1),
+  sms: () => 1,
+  push: ({ urgent }) => (urgent ? 3 : 1),
 });
 
 /** Is this notification unread? */
 const isUnread = notifOps.match({
   email: ({ read }) => !read,
-  sms:   ({ read }) => !read,
-  push:  ({ read }) => !read,
+  sms: ({ read }) => !read,
+  push: ({ read }) => !read,
 });
 
 /** Mark a notification as read — each variant carries `read` so we handle all. */
 const markRead = notifOps.mapAll({
   email: (n) => ({ ...n, read: true }),
-  sms:   (n) => ({ ...n, read: true }),
-  push:  (n) => ({ ...n, read: true }),
+  sms: (n) => ({ ...n, read: true }),
+  push: (n) => ({ ...n, read: true }),
 });
 
 /**
@@ -59,8 +78,8 @@ const markRead = notifOps.mapAll({
  * Only emails have a "Star" action — everything else gets "Dismiss".
  */
 const getAction = notifOps.matchWithDefault({
-  email: ({ starred }) => starred ? 'Unstar' : 'Star',
-  Default: () => 'Dismiss',
+  email: ({ starred }) => (starred ? 'Unstar' : 'Star'),
+  Default: (_value) => 'Dismiss',
 });
 
 // ── Notification store (plain array, no framework required) ───────────────────
@@ -126,8 +145,7 @@ class NotificationStore {
     return match(n)({
       email: ({ from, subject, starred, read }) =>
         `Email from ${from}\nSubject: ${subject}\nStarred: ${starred} | Read: ${read}`,
-      sms: ({ from, body, read }) =>
-        `SMS from ${from}\n${body}\nRead: ${read}`,
+      sms: ({ from, body, read }) => `SMS from ${from}\n${body}\nRead: ${read}`,
       push: ({ app, title, urgent, read }) =>
         `Push from ${app}\n${title}\nUrgent: ${urgent} | Read: ${read}`,
     });
@@ -138,13 +156,42 @@ class NotificationStore {
 
 const store = new NotificationStore();
 
-store.add({ type: 'email', from: 'boss@corp.com', subject: 'Q4 review',  read: false, starred: true });
-store.add({ type: 'sms',   from: '+1-555-0100',   body:    'Your code is ready for pickup.', read: false });
-store.add({ type: 'push',  app: 'GitHub',         title:   'PR #42 merged', read: true, urgent: false });
-store.add({ type: 'push',  app: 'PagerDuty',      title:   '🚨 Prod alert: high error rate', read: false, urgent: true });
-store.add({ type: 'email', from: 'news@digest.io', subject: 'Weekly digest', read: true, starred: false });
+store.add({
+  type: 'email',
+  from: 'boss@corp.com',
+  subject: 'Q4 review',
+  read: false,
+  starred: true,
+});
+store.add({
+  type: 'sms',
+  from: '+1-555-0100',
+  body: 'Your code is ready for pickup.',
+  read: false,
+});
+store.add({
+  type: 'push',
+  app: 'GitHub',
+  title: 'PR #42 merged',
+  read: true,
+  urgent: false,
+});
+store.add({
+  type: 'push',
+  app: 'PagerDuty',
+  title: '🚨 Prod alert: high error rate',
+  read: false,
+  urgent: true,
+});
+store.add({
+  type: 'email',
+  from: 'news@digest.io',
+  subject: 'Weekly digest',
+  read: true,
+  starred: false,
+});
 
-console.log(`Unread: ${store.unreadCount}`);  // 3
+console.log(`Unread: ${store.unreadCount}`); // 3
 console.log(`Emails: ${store.emails.length}`); // 2
 console.log(`Urgent: ${store.urgentPushes.length}`); // 1
 

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -18,8 +18,12 @@ const expectedExports = [
   'count',
   'createPipeHandlers',
   'createUnion',
+  'every',
+  'filterMap',
+  'find',
   'fold',
   'foldWithDefault',
+  'groupBy',
   'is',
   'isUnion',
   'map',
@@ -27,6 +31,7 @@ const expectedExports = [
   'match',
   'matchWithDefault',
   'partition',
+  'some',
 ].sort();
 
 const expectedAsyncExports = [

--- a/src/__tests__/every.test.ts
+++ b/src/__tests__/every.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { every } from '../unions';
+
+type Shape =
+  | { type: 'circle'; radius: number }
+  | { type: 'rectangle'; width: number; height: number }
+  | { type: 'triangle'; base: number; height: number };
+
+type Animal =
+  | { kind: 'dog'; name: string }
+  | { kind: 'cat'; lives: number }
+  | { kind: 'bird'; canFly: boolean };
+
+const circle: Shape = { type: 'circle', radius: 5 };
+const circle2: Shape = { type: 'circle', radius: 10 };
+const rectangle: Shape = { type: 'rectangle', width: 4, height: 6 };
+const triangle: Shape = { type: 'triangle', base: 10, height: 3 };
+
+describe('every — single variant', () => {
+  it('returns true when all items match', () => {
+    expect(every([circle, circle2], 'circle')).toBe(true);
+  });
+
+  it('returns false when any item does not match', () => {
+    expect(every([circle, rectangle], 'circle')).toBe(false);
+  });
+
+  it('returns true for empty array (vacuous truth)', () => {
+    expect(every([] as Shape[], 'circle')).toBe(true);
+  });
+});
+
+describe('every — multi-variant', () => {
+  it('returns true when all items match any of the variants', () => {
+    expect(every([circle, rectangle], ['circle', 'rectangle'])).toBe(true);
+  });
+
+  it('returns false when any item is outside the variant set', () => {
+    expect(every([circle, rectangle, triangle], ['circle', 'rectangle'])).toBe(false);
+  });
+});
+
+describe('every — non-union items skipped', () => {
+  it('skips non-union items and evaluates only union items', () => {
+    const mixed = [null, circle, circle2] as any[];
+    expect(every(mixed, 'circle')).toBe(true);
+  });
+
+  it('returns true for array of only non-union items (vacuous)', () => {
+    const mixed = [null, 'hello', 42] as any[];
+    expect(every(mixed, 'circle')).toBe(true);
+  });
+
+  it('returns false when union items fail the predicate despite non-union items', () => {
+    const mixed = [null, circle, rectangle] as any[];
+    expect(every(mixed, 'circle')).toBe(false);
+  });
+});
+
+describe('every — custom discriminant', () => {
+  const dog: Animal = { kind: 'dog', name: 'Rex' };
+  const cat: Animal = { kind: 'cat', lives: 9 };
+
+  it('returns true when all items match with custom discriminant', () => {
+    const dog2: Animal = { kind: 'dog', name: 'Buddy' };
+    expect(every([dog, dog2], 'dog', 'kind')).toBe(true);
+  });
+
+  it('returns false when not all match with custom discriminant', () => {
+    expect(every([dog, cat], 'dog', 'kind')).toBe(false);
+  });
+});

--- a/src/__tests__/filterMap.test.ts
+++ b/src/__tests__/filterMap.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { filterMap } from '../unions';
+
+type Shape =
+  | { type: 'circle'; radius: number }
+  | { type: 'rectangle'; width: number; height: number }
+  | { type: 'triangle'; base: number; height: number };
+
+type Animal =
+  | { kind: 'dog'; name: string }
+  | { kind: 'cat'; lives: number }
+  | { kind: 'bird'; canFly: boolean };
+
+const circle: Shape = { type: 'circle', radius: 5 };
+const rectangle: Shape = { type: 'rectangle', width: 4, height: 6 };
+const triangle: Shape = { type: 'triangle', base: 10, height: 3 };
+
+describe('filterMap — basic transform+filter', () => {
+  it('transforms handled variants and skips unhandled ones', () => {
+    const areas = filterMap([circle, rectangle, triangle], {
+      circle: ({ radius }) => Math.PI * radius ** 2,
+    });
+    expect(areas).toHaveLength(1);
+    expect(areas[0]).toBeCloseTo(Math.PI * 25);
+  });
+
+  it('transforms multiple handled variants', () => {
+    const result = filterMap([circle, rectangle, triangle], {
+      circle: ({ radius }) => `circle:${radius}`,
+      rectangle: ({ width, height }) => `rect:${width}x${height}`,
+    });
+    expect(result).toEqual(['circle:5', 'rect:4x6']);
+  });
+
+  it('returns empty array when no handlers provided', () => {
+    expect(filterMap([circle, rectangle], {})).toEqual([]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(filterMap([] as Shape[], { circle: ({ radius }) => radius })).toEqual([]);
+  });
+});
+
+describe('filterMap — undefined skips, null keeps', () => {
+  it('skips items whose handler returns undefined', () => {
+    const result = filterMap([circle, rectangle], {
+      circle: ({ radius }) => (radius > 10 ? radius : undefined),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('keeps items whose handler returns null', () => {
+    const result = filterMap([circle], {
+      circle: () => null,
+    });
+    expect(result).toEqual([null]);
+  });
+
+  it('keeps 0 and empty string as valid values', () => {
+    const result = filterMap([circle, rectangle], {
+      circle: () => 0,
+      rectangle: () => '',
+    });
+    expect(result).toEqual([0, '']);
+  });
+});
+
+describe('filterMap — non-union items skipped', () => {
+  it('skips null and non-union entries in the input array', () => {
+    const mixed = [null, circle, undefined, rectangle] as any[];
+    const result = filterMap(mixed, {
+      circle: ({ radius }) => radius,
+    });
+    expect(result).toEqual([5]);
+  });
+});
+
+describe('filterMap — custom discriminant', () => {
+  const dog: Animal = { kind: 'dog', name: 'Rex' };
+  const cat: Animal = { kind: 'cat', lives: 9 };
+
+  it('transforms with custom discriminant', () => {
+    const result = filterMap([dog, cat], {
+      dog: ({ name }) => name.toUpperCase(),
+    }, 'kind');
+    expect(result).toEqual(['REX']);
+  });
+});
+
+describe('filterMap — all handlers covered', () => {
+  it('acts like map when all variants have handlers returning non-undefined', () => {
+    const result = filterMap([circle, rectangle, triangle], {
+      circle: ({ radius }) => radius,
+      rectangle: ({ width, height }) => width * height,
+      triangle: ({ base, height }) => (base * height) / 2,
+    });
+    expect(result).toEqual([5, 24, 15]);
+  });
+});

--- a/src/__tests__/filterMap.test.ts
+++ b/src/__tests__/filterMap.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import { filterMap } from '../unions';
 
 type Shape =
@@ -95,5 +95,14 @@ describe('filterMap — all handlers covered', () => {
       triangle: ({ base, height }) => (base * height) / 2,
     });
     expect(result).toEqual([5, 24, 15]);
+  });
+});
+
+describe('filterMap — type narrowing', () => {
+  it('infers return type from handler return type', () => {
+    const result = filterMap([circle, rectangle], {
+      circle: ({ radius }) => radius,
+    });
+    expectTypeOf(result).toEqualTypeOf<number[]>();
   });
 });

--- a/src/__tests__/filterMap.test.ts
+++ b/src/__tests__/filterMap.test.ts
@@ -99,8 +99,8 @@ describe('filterMap — all handlers covered', () => {
 });
 
 describe('filterMap — type narrowing', () => {
-  it('infers return type from handler return type', () => {
-    const result = filterMap([circle, rectangle], {
+  it('returns Result[] when Result generic is provided', () => {
+    const result = filterMap<Shape, number>([circle, rectangle], {
       circle: ({ radius }) => radius,
     });
     expectTypeOf(result).toEqualTypeOf<number[]>();

--- a/src/__tests__/find.test.ts
+++ b/src/__tests__/find.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { find } from '../unions';
+
+type Shape =
+  | { type: 'circle'; radius: number }
+  | { type: 'rectangle'; width: number; height: number }
+  | { type: 'triangle'; base: number; height: number };
+
+type Animal =
+  | { kind: 'dog'; name: string }
+  | { kind: 'cat'; lives: number }
+  | { kind: 'bird'; canFly: boolean };
+
+const circle: Shape = { type: 'circle', radius: 5 };
+const rectangle: Shape = { type: 'rectangle', width: 4, height: 6 };
+const triangle: Shape = { type: 'triangle', base: 10, height: 3 };
+
+describe('find — single variant', () => {
+  it('returns first matching item', () => {
+    const shapes = [rectangle, circle, triangle];
+    expect(find(shapes, 'circle')).toBe(circle);
+  });
+
+  it('returns the first match when multiple exist', () => {
+    const c2: Shape = { type: 'circle', radius: 99 };
+    expect(find([circle, rectangle, c2], 'circle')).toBe(circle);
+  });
+
+  it('returns undefined when no match', () => {
+    expect(find([rectangle, triangle] as Shape[], 'circle')).toBeUndefined();
+  });
+
+  it('returns undefined for empty array', () => {
+    expect(find([] as Shape[], 'circle')).toBeUndefined();
+  });
+});
+
+describe('find — multi-variant', () => {
+  it('returns first item matching any of the variants', () => {
+    const shapes = [triangle, rectangle, circle];
+    const result = find(shapes, ['circle', 'rectangle']);
+    expect(result).toBe(rectangle);
+  });
+
+  it('returns undefined when none match', () => {
+    expect(find([triangle] as Shape[], ['circle', 'rectangle'])).toBeUndefined();
+  });
+});
+
+describe('find — non-union items skipped', () => {
+  it('skips null entries', () => {
+    const mixed = [null, undefined, circle] as any[];
+    expect(find(mixed, 'circle')).toBe(circle);
+  });
+
+  it('skips objects without string discriminant', () => {
+    const mixed = [{ type: 42 }, circle] as any[];
+    expect(find(mixed, 'circle')).toBe(circle);
+  });
+});
+
+describe('find — custom discriminant', () => {
+  const dog: Animal = { kind: 'dog', name: 'Rex' };
+  const cat: Animal = { kind: 'cat', lives: 9 };
+
+  it('finds with custom discriminant', () => {
+    expect(find([cat, dog], 'dog', 'kind')).toBe(dog);
+  });
+
+  it('returns undefined when not found with custom discriminant', () => {
+    expect(find([cat] as Animal[], 'dog', 'kind')).toBeUndefined();
+  });
+});
+
+describe('find — type narrowing', () => {
+  it('narrows single-variant result to that variant type', () => {
+    const result = find([circle, rectangle], 'circle');
+    expectTypeOf(result).toEqualTypeOf<{ type: 'circle'; radius: number } | undefined>();
+  });
+
+  it('narrows multi-variant result to sub-union', () => {
+    const result = find([circle, rectangle, triangle], ['circle', 'rectangle'] as const);
+    expectTypeOf(result).toEqualTypeOf<
+      { type: 'circle'; radius: number } | { type: 'rectangle'; width: number; height: number } | undefined
+    >();
+  });
+});

--- a/src/__tests__/groupBy.test.ts
+++ b/src/__tests__/groupBy.test.ts
@@ -73,7 +73,7 @@ describe('groupBy — custom discriminant', () => {
 describe('groupBy — type narrowing', () => {
   it('each group is narrowed to the specific variant type', () => {
     const result = groupBy([circle, rectangle]);
-    expectTypeOf(result.circle).toEqualTypeOf<{ type: 'circle'; radius: number }[]>();
-    expectTypeOf(result.rectangle).toEqualTypeOf<{ type: 'rectangle'; width: number; height: number }[]>();
+    expectTypeOf(result.circle).toEqualTypeOf<{ type: 'circle'; radius: number }[] | undefined>();
+    expectTypeOf(result.rectangle).toEqualTypeOf<{ type: 'rectangle'; width: number; height: number }[] | undefined>();
   });
 });

--- a/src/__tests__/groupBy.test.ts
+++ b/src/__tests__/groupBy.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { groupBy } from '../unions';
+
+type Shape =
+  | { type: 'circle'; radius: number }
+  | { type: 'rectangle'; width: number; height: number }
+  | { type: 'triangle'; base: number; height: number };
+
+type Animal =
+  | { kind: 'dog'; name: string }
+  | { kind: 'cat'; lives: number }
+  | { kind: 'bird'; canFly: boolean };
+
+const circle: Shape = { type: 'circle', radius: 5 };
+const circle2: Shape = { type: 'circle', radius: 10 };
+const rectangle: Shape = { type: 'rectangle', width: 4, height: 6 };
+const triangle: Shape = { type: 'triangle', base: 10, height: 3 };
+
+describe('groupBy — basic grouping', () => {
+  it('groups items by variant', () => {
+    const result = groupBy([circle, rectangle, circle2, triangle]);
+    expect(result.circle).toEqual([circle, circle2]);
+    expect(result.rectangle).toEqual([rectangle]);
+    expect(result.triangle).toEqual([triangle]);
+  });
+
+  it('returns an empty object for an empty array', () => {
+    const result = groupBy([] as Shape[]);
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('groups a single item correctly', () => {
+    const result = groupBy([circle]);
+    expect(result.circle).toEqual([circle]);
+  });
+
+  it('preserves insertion order within each group', () => {
+    const c1: Shape = { type: 'circle', radius: 1 };
+    const c2: Shape = { type: 'circle', radius: 2 };
+    const c3: Shape = { type: 'circle', radius: 3 };
+    const result = groupBy([c1, rectangle, c2, c3]);
+    expect(result.circle).toEqual([c1, c2, c3]);
+  });
+});
+
+describe('groupBy — non-union items skipped', () => {
+  it('skips null and undefined', () => {
+    const mixed = [null, circle, undefined, rectangle] as any[];
+    const result = groupBy(mixed);
+    expect(result.circle).toEqual([circle]);
+    expect(result.rectangle).toEqual([rectangle]);
+  });
+
+  it('skips objects without string discriminant', () => {
+    const mixed = [{ type: 42 }, circle] as any[];
+    const result = groupBy(mixed);
+    expect(result.circle).toEqual([circle]);
+  });
+});
+
+describe('groupBy — custom discriminant', () => {
+  const dog: Animal = { kind: 'dog', name: 'Rex' };
+  const cat: Animal = { kind: 'cat', lives: 9 };
+  const dog2: Animal = { kind: 'dog', name: 'Buddy' };
+
+  it('groups with custom discriminant', () => {
+    const result = groupBy([dog, cat, dog2], 'kind');
+    expect(result.dog).toEqual([dog, dog2]);
+    expect(result.cat).toEqual([cat]);
+  });
+});
+
+describe('groupBy — type narrowing', () => {
+  it('each group is narrowed to the specific variant type', () => {
+    const result = groupBy([circle, rectangle]);
+    expectTypeOf(result.circle).toEqualTypeOf<{ type: 'circle'; radius: number }[]>();
+    expectTypeOf(result.rectangle).toEqualTypeOf<{ type: 'rectangle'; width: number; height: number }[]>();
+  });
+});

--- a/src/__tests__/match-with-default-async.test.ts
+++ b/src/__tests__/match-with-default-async.test.ts
@@ -38,7 +38,7 @@ describe('matchWithDefaultAsync', () => {
   it('passes payload to Default', async () => {
     const out = await matchWithDefaultAsync(pending, 'type', 'x')({
       ok: async ({ value }, p) => `ok:${value}:${p}`,
-      Default: (p) => `default:${p}`,
+      Default: (_item, p) => `default:${p}`,
     });
     expect(out).toBe('default:x');
   });

--- a/src/__tests__/payload.test.ts
+++ b/src/__tests__/payload.test.ts
@@ -22,8 +22,10 @@ describe('createPipeHandlers with payload', () => {
     it('accepts payload as second arg to the returned function', () => {
       const fn = shapeOps.match<string, Context>({
         circle: ({ radius }, p) => `${p.label}:${radius * p.scale}`,
-        rectangle: ({ width, height }, p) => `${p.label}:${width * height * p.scale}`,
-        triangle: ({ base, height }, p) => `${p.label}:${(base * height) / 2 * p.scale}`,
+        rectangle: ({ width, height }, p) =>
+          `${p.label}:${width * height * p.scale}`,
+        triangle: ({ base, height }, p) =>
+          `${p.label}:${((base * height) / 2) * p.scale}`,
       });
       expect(fn(circle, ctx)).toBe('test:10');
       expect(fn(rectangle, ctx)).toBe('test:48');
@@ -31,19 +33,16 @@ describe('createPipeHandlers with payload', () => {
   });
 
   describe('matchWithDefault', () => {
+    const fn = shapeOps.matchWithDefault<string, Context>({
+      circle: ({ radius }, p) => `${p.label}:${radius * p.scale}`,
+      Default: (_item, p) => `${p.label}:other`,
+    });
+
     it('passes payload to matched handler', () => {
-      const fn = shapeOps.matchWithDefault<string, Context>({
-        circle: ({ radius }, p) => `${p.label}:${radius * p.scale}`,
-        Default: (p) => `${p.label}:other`,
-      });
       expect(fn(circle, ctx)).toBe('test:10');
     });
 
     it('passes payload to Default when no variant matched', () => {
-      const fn = shapeOps.matchWithDefault<string, Context>({
-        circle: ({ radius }, p) => `${p.label}:${radius * p.scale}`,
-        Default: (p) => `${p.label}:other`,
-      });
       expect(fn(triangle, ctx)).toBe('test:other');
     });
   });
@@ -71,7 +70,11 @@ describe('createPipeHandlers with payload', () => {
         }),
       });
       expect(fn(circle, ctx)).toEqual({ type: 'circle', radius: 10 });
-      expect(fn(rectangle, ctx)).toEqual({ type: 'rectangle', width: 8, height: 12 });
+      expect(fn(rectangle, ctx)).toEqual({
+        type: 'rectangle',
+        width: 8,
+        height: 12,
+      });
     });
   });
 });
@@ -88,8 +91,10 @@ describe('createUnion with payload', () => {
   it('match passes payload to handler', () => {
     const fn = Shape.match<string, Context>({
       circle: ({ radius }, p) => `${p.label}:${radius * p.scale}`,
-      rectangle: ({ width, height }, p) => `${p.label}:${width * height * p.scale}`,
-      triangle: ({ base, height }, p) => `${p.label}:${(base * height) / 2 * p.scale}`,
+      rectangle: ({ width, height }, p) =>
+        `${p.label}:${width * height * p.scale}`,
+      triangle: ({ base, height }, p) =>
+        `${p.label}:${((base * height) / 2) * p.scale}`,
     });
     expect(fn(Shape.circle(5), ctx)).toBe('test:10');
   });
@@ -97,7 +102,7 @@ describe('createUnion with payload', () => {
   it('matchWithDefault passes payload to Default', () => {
     const fn = Shape.matchWithDefault<string, Context>({
       circle: ({ radius }, p) => `${p.label}:${radius}`,
-      Default: (p) => `${p.label}:unknown`,
+      Default: (_item, p) => `${p.label}:unknown`,
     });
     expect(fn(Shape.triangle(10, 3), ctx)).toBe('test:unknown');
   });

--- a/src/__tests__/some.test.ts
+++ b/src/__tests__/some.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { some } from '../unions';
+
+type Shape =
+  | { type: 'circle'; radius: number }
+  | { type: 'rectangle'; width: number; height: number }
+  | { type: 'triangle'; base: number; height: number };
+
+type Animal =
+  | { kind: 'dog'; name: string }
+  | { kind: 'cat'; lives: number }
+  | { kind: 'bird'; canFly: boolean };
+
+const circle: Shape = { type: 'circle', radius: 5 };
+const rectangle: Shape = { type: 'rectangle', width: 4, height: 6 };
+const triangle: Shape = { type: 'triangle', base: 10, height: 3 };
+
+describe('some — single variant', () => {
+  it('returns true when at least one item matches', () => {
+    expect(some([rectangle, circle, triangle], 'circle')).toBe(true);
+  });
+
+  it('returns false when no item matches', () => {
+    expect(some([rectangle, triangle] as Shape[], 'circle')).toBe(false);
+  });
+
+  it('returns false for empty array', () => {
+    expect(some([] as Shape[], 'circle')).toBe(false);
+  });
+});
+
+describe('some — multi-variant', () => {
+  it('returns true when any item matches any of the variants', () => {
+    expect(some([triangle] as Shape[], ['circle', 'triangle'])).toBe(true);
+  });
+
+  it('returns false when no item matches any variant', () => {
+    expect(some([triangle] as Shape[], ['circle', 'rectangle'])).toBe(false);
+  });
+});
+
+describe('some — non-union items skipped', () => {
+  it('skips null, undefined, and non-union objects', () => {
+    const mixed = [null, undefined, { type: 42 }, circle] as any[];
+    expect(some(mixed, 'circle')).toBe(true);
+  });
+
+  it('returns false for array of only non-union items', () => {
+    const mixed = [null, 'hello', 42] as any[];
+    expect(some(mixed, 'circle')).toBe(false);
+  });
+});
+
+describe('some — custom discriminant', () => {
+  const dog: Animal = { kind: 'dog', name: 'Rex' };
+  const cat: Animal = { kind: 'cat', lives: 9 };
+
+  it('returns true with custom discriminant', () => {
+    expect(some([cat, dog], 'dog', 'kind')).toBe(true);
+  });
+
+  it('returns false with custom discriminant when not found', () => {
+    expect(some([cat] as Animal[], 'dog', 'kind')).toBe(false);
+  });
+});

--- a/src/__tests__/unions.test.ts
+++ b/src/__tests__/unions.test.ts
@@ -173,6 +173,32 @@ describe('matchWithDefault', () => {
       'Not a union',
     );
   });
+
+  it('Default receives the unhandled item at runtime', () => {
+    const received: Shape[] = [];
+    matchWithDefault(triangle)({
+      circle: ({ radius }) => radius,
+      Default: (item) => { received.push(item); return 0; },
+    });
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe(triangle);
+  });
+
+  it('Default receives the full item when no variants are handled', () => {
+    const received: Shape[] = [];
+    matchWithDefault(circle)({
+      Default: (item) => { received.push(item); return 'x'; },
+    });
+    expect(received[0]).toBe(circle);
+  });
+
+  it('Default: () => result (no declared params) still works', () => {
+    const result = matchWithDefault(triangle)({
+      circle: ({ radius }) => `circle:${radius}`,
+      Default: () => 'fallback',
+    });
+    expect(result).toBe('fallback');
+  });
 });
 
 describe('map', () => {

--- a/src/async.ts
+++ b/src/async.ts
@@ -65,6 +65,7 @@ export function matchAsync<
 /**
  * Async pattern matching with `Default` fallback. Like `matchWithDefault`,
  * but handlers may return `Promise<R>` or `R`. Result unified to `Promise<R>`.
+ * `Default` receives the unhandled union item, typed as the sub-union of variants with no explicit handler.
  */
 export function matchWithDefaultAsync<
   T extends SampleUnion<Discriminant>,
@@ -75,11 +76,15 @@ export function matchWithDefaultAsync<
   discriminant: Discriminant = DEFAULT_DISCRIMINANT as Discriminant,
   payload?: Payload,
 ): <U>(
-  matcher: AsyncMatcherWithDefault<T, U, Discriminant, Payload>,
+  matcher: Partial<AsyncMatcher<T, U, Discriminant, Payload>> & {
+    Default: (item: T, ...payload: [Payload] extends [never] ? [] : [payload: Payload]) => U | Promise<U>;
+  },
 ) => Promise<U> {
   ensureUnion(input, discriminant, matchWithDefaultAsync);
   return async <U>(
-    matcher: AsyncMatcherWithDefault<T, U, Discriminant, Payload>,
+    matcher: Partial<AsyncMatcher<T, U, Discriminant, Payload>> & {
+      Default: (item: T, ...payload: [Payload] extends [never] ? [] : [payload: Payload]) => U | Promise<U>;
+    },
   ) =>
     dispatch<T, U | Promise<U>, Discriminant, Payload>(
       input,
@@ -163,7 +168,7 @@ export function mapAsync<
         (input: any, payload: Payload) => T | Promise<T>
       >,
       discriminant,
-      () => input,
+      (_: T) => input,
       payload,
       mapAsync,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,11 @@ export {
   foldWithDefault,
   count,
   partition,
+  find,
+  some,
+  every,
+  groupBy,
+  filterMap,
   createPipeHandlers,
   createUnion,
   is,
@@ -22,4 +27,6 @@ export type {
   MapperAll,
   Folder,
   FolderWithDefault,
+  FilterMapHandlers,
+  GroupByResult,
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -332,7 +332,7 @@ export type GroupByResult<
   T extends SampleUnion<Discriminant>,
   Discriminant extends PropertyKey,
 > = {
-  [K in T[Discriminant]]: Extract<T, { [D in Discriminant]: K }>[];
+  [K in T[Discriminant]]?: Extract<T, { [D in Discriminant]: K }>[];
 };
 
 type SchemaData<D extends string> = object & { [Disc in D]?: never };

--- a/src/types.ts
+++ b/src/types.ts
@@ -489,7 +489,7 @@ export type UnionFactory<D extends string, Schema extends UnionSchema<D>> = {
   ) => (items: ReadonlyArray<InferUnionFromSchema<D, Schema>>) => boolean;
   readonly groupBy: (
     items: ReadonlyArray<InferUnionFromSchema<D, Schema>>,
-  ) => { [K in keyof Schema & string]: Extract<InferUnionFromSchema<D, Schema>, { [Disc in D]: K }>[] };
+  ) => GroupByResult<InferUnionFromSchema<D, Schema>, D>;
   readonly filterMap: <Result>(
     handlers: FilterMapHandlers<InferUnionFromSchema<D, Schema>, Result, D>,
   ) => (items: ReadonlyArray<InferUnionFromSchema<D, Schema>>) => Result[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,13 +76,10 @@ export type Matcher<
 /**
  * Partial handler map with a required `Default` fallback for unmatched variants.
  * Unlike {@link Matcher}, individual variant handlers are optional. When a variant
- * has no handler, the `Default` function is called instead.
+ * has no handler, `Default` is called with the full union item.
  *
- * **Design limitation:** `Default` does not receive the triggering variant as an argument.
- * When `Payload = never` (the default), `Default` receives no arguments at all — there
- * is no way to inspect which variant fell through inside `Default`. If you need to
- * branch on the unmatched variant, use exhaustive {@link Matcher} instead, or pass the
- * original value via the `Payload` type parameter.
+ * `Default` receives the item as its first argument, typed as `T`. Narrow the variant
+ * inside `Default` using the discriminant property (e.g. `item.type`).
  *
  * @typeParam T - The discriminated union type
  * @typeParam Result - The return type of all handler functions (including Default)
@@ -93,7 +90,7 @@ export type Matcher<
  *
  * const describe: MatcherWithDefault<Shape, string> = {
  *   circle: ({ radius }) => `Circle with radius ${radius}`,
- *   Default: () => 'Unknown shape', // ← cannot inspect which variant fell through
+ *   Default: (item) => `Other: ${item.type}`,
  * };
  * ```
  */
@@ -103,9 +100,7 @@ export type MatcherWithDefault<
   Discriminant extends PropertyKey,
   Payload extends any = never,
 > = Partial<Matcher<T, Result, Discriminant, Payload>> & {
-  Default: (
-    ...args: [Payload] extends [never] ? [] : [payload: Payload]
-  ) => Result;
+  Default: (item: T, ...payload: [Payload] extends [never] ? [] : [payload: Payload]) => Result;
 };
 
 /**
@@ -246,6 +241,7 @@ export type AsyncMatcher<
 /**
  * Async partial handler map with a required `Default` fallback.
  * Each handler (including `Default`) may return `Result` or `Promise<Result>`.
+ * `Default` receives the full union item as its first argument.
  */
 export type AsyncMatcherWithDefault<
   T extends SampleUnion<Discriminant>,
@@ -253,9 +249,7 @@ export type AsyncMatcherWithDefault<
   Discriminant extends PropertyKey,
   Payload extends any = never,
 > = Partial<AsyncMatcher<T, Result, Discriminant, Payload>> & {
-  Default: (
-    ...args: [Payload] extends [never] ? [] : [payload: Payload]
-  ) => Result | Promise<Result>;
+  Default: (item: T, ...payload: [Payload] extends [never] ? [] : [payload: Payload]) => Result | Promise<Result>;
 };
 
 /**
@@ -315,6 +309,32 @@ export type TakeDiscriminant<T, K extends keyof T = keyof T> = K extends keyof T
     : never
   : never;
 
+/**
+ * Partial handler map for `filterMap`. Each handler receives the variant's data
+ * and returns a transformed value to keep, or `undefined` to skip.
+ * Variants with no handler are silently skipped.
+ */
+export type FilterMapHandlers<
+  T extends SampleUnion<Discriminant>,
+  Result,
+  Discriminant extends PropertyKey,
+> = {
+  [K in T[Discriminant]]?: T extends Model<K, infer Data, Discriminant>
+    ? (input: Data) => Result | undefined
+    : never;
+};
+
+/**
+ * Return type of `groupBy`. Each variant key maps to a narrowed array of that variant.
+ * Keys for variants absent from the input may be missing at runtime.
+ */
+export type GroupByResult<
+  T extends SampleUnion<Discriminant>,
+  Discriminant extends PropertyKey,
+> = {
+  [K in T[Discriminant]]: Extract<T, { [D in Discriminant]: K }>[];
+};
+
 type SchemaData<D extends string> = object & { [Disc in D]?: never };
 
 export type ReservedUnionKeys =
@@ -328,6 +348,11 @@ export type ReservedUnionKeys =
   | 'foldWithDefault'
   | 'count'
   | 'partition'
+  | 'find'
+  | 'some'
+  | 'every'
+  | 'groupBy'
+  | 'filterMap'
   | 'variants'
   | 'discriminant'
   | '_union';
@@ -451,6 +476,23 @@ export type UnionFactory<D extends string, Schema extends UnionSchema<D>> = {
     Extract<InferUnionFromSchema<D, Schema>, { [Disc in D]: U }>[],
     Exclude<InferUnionFromSchema<D, Schema>, { [Disc in D]: U }>[],
   ];
+  readonly find: <U extends keyof Schema & string>(
+    variants: U | readonly U[],
+  ) => (
+    items: ReadonlyArray<InferUnionFromSchema<D, Schema>>,
+  ) => Extract<InferUnionFromSchema<D, Schema>, { [Disc in D]: U }> | undefined;
+  readonly some: (
+    variants: (keyof Schema & string) | ReadonlyArray<keyof Schema & string>,
+  ) => (items: ReadonlyArray<InferUnionFromSchema<D, Schema>>) => boolean;
+  readonly every: (
+    variants: (keyof Schema & string) | ReadonlyArray<keyof Schema & string>,
+  ) => (items: ReadonlyArray<InferUnionFromSchema<D, Schema>>) => boolean;
+  readonly groupBy: (
+    items: ReadonlyArray<InferUnionFromSchema<D, Schema>>,
+  ) => { [K in keyof Schema & string]: Extract<InferUnionFromSchema<D, Schema>, { [Disc in D]: K }>[] };
+  readonly filterMap: <Result>(
+    handlers: FilterMapHandlers<InferUnionFromSchema<D, Schema>, Result, D>,
+  ) => (items: ReadonlyArray<InferUnionFromSchema<D, Schema>>) => Result[];
   readonly variants: ReadonlyArray<keyof Schema & string>;
   readonly discriminant: D;
   /**

--- a/src/unions.ts
+++ b/src/unions.ts
@@ -605,7 +605,9 @@ export function some<
 
 /**
  * Returns `true` if every item in the collection matches the given variant(s).
- * Non-union items are silently skipped. Returns `true` for an empty collection.
+ * Non-union items are silently skipped. Returns `true` for an empty collection
+ * (vacuous truth). A collection containing only non-union items is treated as
+ * empty and also returns `true`.
  *
  * @example
  * ```ts
@@ -703,8 +705,9 @@ export function filterMap<
  *
  * @param discriminant - The property used to tell variants apart (e.g. `'type'` or `'kind'`)
  * @returns An object with handler-first utilities including `match`, `matchWithDefault`,
- *   `map`, `mapAll`, `fold`, `foldWithDefault`, `count`, `partition`, and `is` — each returning a reusable
- *   function that accepts the input value
+ *   `map`, `mapAll`, `fold`, `foldWithDefault`, `count`, `partition`, `find`, `some`,
+ *   `every`, `groupBy`, `filterMap`, and `is` — each returning a reusable function
+ *   that accepts the input value
  *
  * @example
  * ```ts

--- a/src/unions.ts
+++ b/src/unions.ts
@@ -1,6 +1,8 @@
 import {
+  FilterMapHandlers,
   Folder,
   FolderWithDefault,
+  GroupByResult,
   InferUnionFromSchema,
   Mapper,
   MapperAll,
@@ -106,14 +108,14 @@ export function dispatch<
     ((input: any, payload: Payload) => Result) | undefined
   >,
   discriminant: Discriminant,
-  fallback: ((payload: Payload) => Result) | undefined,
+  fallback: ((item: T, payload: Payload) => Result) | undefined,
   payload: Payload | undefined,
   caller: Function,
 ): Result {
   const key = union[discriminant] as string;
   const fn = Object.hasOwn(handlers, key) ? handlers[key] : undefined;
   if (fn) return fn(union, payload!);
-  if (fallback) return fallback(payload!);
+  if (fallback) return fallback(union, payload!);
   return rethrow(new UnknownVariantError(key, Object.keys(handlers)), caller);
 }
 
@@ -356,11 +358,7 @@ export function match<
 
 /**
  * Pattern matching with a fallback. Handle specific variants explicitly; `Default` catches the rest.
- *
- * **Design limitation:** The `Default` handler does not receive the triggering variant —
- * it cannot determine which variant fell through. When no `Payload` is used, `Default`
- * receives no arguments at all. To inspect the unmatched variant inside `Default`, either
- * switch to exhaustive {@link match}, or pass the original value as `payload`.
+ * `Default` receives the unhandled union item — typed as the sub-union of variants that have no handler.
  *
  * @param input - The discriminated union value to match against
  * @param discriminant - The property used to tell variants apart. Defaults to `'type'`.
@@ -371,7 +369,7 @@ export function match<
  * ```ts
  * const label = matchWithDefault(shape)({
  *   circle: ({ radius }) => `Circle r=${radius}`,
- *   Default: () => 'Some other shape', // ← no access to which variant triggered Default
+ *   Default: (item) => `Other shape: ${item.type}`, // item is typed as the unhandled sub-union
  * });
  * ```
  */
@@ -383,9 +381,17 @@ export function matchWithDefault<
   input: T,
   discriminant: Discriminant = DEFAULT_DISCRIMINANT as Discriminant,
   payload?: Payload,
-): <U>(matcher: MatcherWithDefault<T, U, Discriminant, Payload>) => U {
+): <U>(
+  matcher: Partial<Matcher<T, U, Discriminant, Payload>> & {
+    Default: (item: T, ...payload: [Payload] extends [never] ? [] : [payload: Payload]) => U;
+  },
+) => U {
   ensureUnion(input, discriminant, matchWithDefault);
-  return <U>(matcher: MatcherWithDefault<T, U, Discriminant, Payload>) =>
+  return <U>(
+    matcher: Partial<Matcher<T, U, Discriminant, Payload>> & {
+      Default: (item: T, ...payload: [Payload] extends [never] ? [] : [payload: Payload]) => U;
+    },
+  ) =>
     dispatch<T, U, Discriminant, Payload>(
       input,
       matcher as unknown as Record<string, (input: any, payload: Payload) => U>,
@@ -542,6 +548,155 @@ export function partition<
 }
 
 /**
+ * Returns the first item in a collection matching the given variant(s), narrowed to that type,
+ * or `undefined` if no match is found. Non-union items are silently skipped.
+ *
+ * @example
+ * ```ts
+ * find(shapes, 'circle');              // Circle | undefined
+ * find(shapes, ['circle', 'rect']);    // Circle | Rect | undefined
+ * find(events, 'click', 'kind');       // custom discriminant
+ * ```
+ */
+export function find<
+  T extends SampleUnion<Discriminant>,
+  U extends T[Discriminant],
+  Discriminant extends PropertyKey = 'type',
+>(
+  items: readonly T[],
+  variants: U | readonly U[],
+  discriminant: Discriminant = DEFAULT_DISCRIMINANT as Discriminant,
+): Extract<T, { [K in Discriminant]: U }> | undefined {
+  const keySet = new Set(([] as string[]).concat(variants as any));
+  for (const item of items) {
+    if (!isUnion(item, discriminant)) continue;
+    if (keySet.has(item[discriminant] as string))
+      return item as Extract<T, { [K in Discriminant]: U }>;
+  }
+  return undefined;
+}
+
+/**
+ * Returns `true` if any item in the collection matches the given variant(s).
+ * Non-union items are silently skipped.
+ *
+ * @example
+ * ```ts
+ * some(shapes, 'circle');                // boolean
+ * some(shapes, ['circle', 'rect']);      // boolean
+ * some(events, 'click', 'kind');         // custom discriminant
+ * ```
+ */
+export function some<
+  T extends SampleUnion<Discriminant>,
+  Discriminant extends PropertyKey = 'type',
+>(
+  items: readonly T[],
+  variants: T[Discriminant] | readonly T[Discriminant][],
+  discriminant: Discriminant = DEFAULT_DISCRIMINANT as Discriminant,
+): boolean {
+  const keySet = new Set(([] as string[]).concat(variants as any));
+  for (const item of items) {
+    if (!isUnion(item, discriminant)) continue;
+    if (keySet.has(item[discriminant] as string)) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns `true` if every item in the collection matches the given variant(s).
+ * Non-union items are silently skipped. Returns `true` for an empty collection.
+ *
+ * @example
+ * ```ts
+ * every(shapes, 'circle');              // true only if all shapes are circles
+ * every(shapes, ['circle', 'rect']);    // true if no triangles
+ * every(events, 'click', 'kind');       // custom discriminant
+ * ```
+ */
+export function every<
+  T extends SampleUnion<Discriminant>,
+  Discriminant extends PropertyKey = 'type',
+>(
+  items: readonly T[],
+  variants: T[Discriminant] | readonly T[Discriminant][],
+  discriminant: Discriminant = DEFAULT_DISCRIMINANT as Discriminant,
+): boolean {
+  const keySet = new Set(([] as string[]).concat(variants as any));
+  for (const item of items) {
+    if (!isUnion(item, discriminant)) continue;
+    if (!keySet.has(item[discriminant] as string)) return false;
+  }
+  return true;
+}
+
+/**
+ * Groups a collection by variant, returning an object keyed by variant name.
+ * Each group is narrowed to the specific variant type. Non-union items are silently skipped.
+ * Keys for variants absent from the input will not be present at runtime.
+ *
+ * @example
+ * ```ts
+ * const groups = groupBy(shapes);
+ * groups.circle;    // Circle[]
+ * groups.rect;      // Rectangle[]
+ * ```
+ */
+export function groupBy<
+  T extends SampleUnion<Discriminant>,
+  Discriminant extends PropertyKey = 'type',
+>(
+  items: readonly T[],
+  discriminant: Discriminant = DEFAULT_DISCRIMINANT as Discriminant,
+): GroupByResult<T, Discriminant> {
+  const result: Record<string, T[]> = {};
+  for (const item of items) {
+    if (!isUnion(item, discriminant)) continue;
+    const key = item[discriminant] as string;
+    if (!Object.hasOwn(result, key)) result[key] = [];
+    result[key].push(item);
+  }
+  return result as GroupByResult<T, Discriminant>;
+}
+
+/**
+ * Filters and transforms a collection in a single pass. Each handler receives the
+ * variant's data and returns a transformed value to keep, or `undefined` to skip.
+ * Variants with no handler are silently skipped. `null` is a valid kept value.
+ * Non-union items are silently skipped.
+ *
+ * @example
+ * ```ts
+ * const areas = filterMap(shapes, {
+ *   circle: ({ radius }) => Math.PI * radius ** 2,
+ *   // rectangle omitted — skipped
+ * });
+ * ```
+ */
+export function filterMap<
+  T extends SampleUnion<Discriminant>,
+  Result,
+  Discriminant extends PropertyKey = 'type',
+>(
+  items: readonly T[],
+  handlers: FilterMapHandlers<T, Result, Discriminant>,
+  discriminant: Discriminant = DEFAULT_DISCRIMINANT as Discriminant,
+): Result[] {
+  const result: Result[] = [];
+  for (const item of items) {
+    if (!isUnion(item, discriminant)) continue;
+    const key = item[discriminant] as string;
+    const handler = Object.hasOwn(handlers, key)
+      ? (handlers as any)[key]
+      : undefined;
+    if (!handler) continue;
+    const value = handler(item);
+    if (value !== undefined) result.push(value);
+  }
+  return result;
+}
+
+/**
  * Creates a pipe-friendly handler factory bound to a specific discriminant key.
  * Returns an object whose methods follow the reversed-curry shape `(handlers) => (input) => result`,
  * making them composable inside FP `pipe` utilities without wrapper lambdas.
@@ -640,6 +795,30 @@ export function createPipeHandlers<
       <U extends T[Discriminant]>(variants: U | readonly U[]) =>
       (input: T): input is Extract<T, { [K in Discriminant]: U }> =>
         is(input, variants as string | readonly string[], discriminant),
+
+    find:
+      <U extends T[Discriminant]>(variants: U | readonly U[]) =>
+      (items: readonly T[]): Extract<T, { [K in Discriminant]: U }> | undefined =>
+        find(items, variants, discriminant),
+
+    some:
+      (variants: T[Discriminant] | readonly T[Discriminant][]) =>
+      (items: readonly T[]): boolean =>
+        some(items, variants, discriminant),
+
+    every:
+      (variants: T[Discriminant] | readonly T[Discriminant][]) =>
+      (items: readonly T[]): boolean =>
+        every(items, variants, discriminant),
+
+    groupBy:
+      (items: readonly T[]): GroupByResult<T, Discriminant> =>
+        groupBy(items, discriminant),
+
+    filterMap:
+      <Result>(handlers: FilterMapHandlers<T, Result, Discriminant>) =>
+      (items: readonly T[]): Result[] =>
+        filterMap(items, handlers, discriminant),
   };
 }
 
@@ -679,6 +858,7 @@ export function createPipeHandlers<
 const RESERVED_UNION_KEYS = new Set<string>([
   'is', 'isKnown', 'match', 'matchWithDefault', 'map', 'mapAll',
   'fold', 'foldWithDefault', 'count', 'partition',
+  'find', 'some', 'every', 'groupBy', 'filterMap',
   'variants', 'discriminant', '_union',
 ]);
 

--- a/src/unions.ts
+++ b/src/unions.ts
@@ -640,8 +640,8 @@ export function every<
  * @example
  * ```ts
  * const groups = groupBy(shapes);
- * groups.circle;    // Circle[]
- * groups.rect;      // Rectangle[]
+ * groups.circle;    // Circle[] | undefined
+ * groups.rect;      // Rectangle[] | undefined
  * ```
  */
 export function groupBy<

--- a/test/published-types/smoke.ts
+++ b/test/published-types/smoke.ts
@@ -1,4 +1,14 @@
-import { createUnion, match, type InferUnion } from 'dismatch';
+import {
+  createUnion,
+  match,
+  matchWithDefault,
+  find,
+  some,
+  every,
+  groupBy,
+  filterMap,
+  type InferUnion,
+} from 'dismatch';
 
 const Result = createUnion('type', {
   ok: (data: string) => ({ data }),
@@ -73,3 +83,44 @@ Result.map({
   type: 'ok',
   message: '',
 }) satisfies ReturnType<NonNullable<Parameters<typeof Result.map>[0]['error']>>;
+
+declare const anyResult: Result;
+
+// Default receives the full union item — narrow with item.type inside Default
+matchWithDefault(anyResult)({
+  ok: ({ data }) => data.length,
+  Default: (item) => {
+    item.type; // discriminant always present — compiles
+    // @ts-expect-error 'data' does not exist on all variants of Result
+    item.data;
+    return 0;
+  },
+});
+
+// Default: () => result (no declared params) still compiles — non-breaking
+matchWithDefault(anyResult)({
+  ok: ({ data }) => data.length,
+  Default: () => 0,
+});
+
+declare const results: Result[];
+
+// find — narrows to the specific variant or undefined
+const found: { type: 'ok'; data: string } | undefined = find(results, 'ok');
+
+// some / every — boolean predicates
+const hasOk: boolean = some(results, 'ok');
+const allOk: boolean = every(results, 'ok');
+const multiSome: boolean = some(results, ['ok', 'loading'] as const);
+
+// groupBy — each group is narrowed to the variant type
+const groups = groupBy(results);
+const okGroup: { type: 'ok'; data: string }[] = groups.ok;
+
+// filterMap — transforms and filters in one pass
+const lengths: number[] = filterMap(results, {
+  ok: ({ data }) => data.length,
+  // error and loading omitted — silently skipped
+});
+
+found; hasOk; allOk; multiSome; okGroup; lengths;

--- a/test/published-types/smoke.ts
+++ b/test/published-types/smoke.ts
@@ -115,7 +115,10 @@ const multiSome: boolean = some(results, ['ok', 'loading'] as const);
 
 // groupBy — each group is narrowed to the variant type
 const groups = groupBy(results);
-const okGroup: { type: 'ok'; data: string }[] = groups.ok;
+const okGroup: { type: 'ok'; data: string }[] | undefined = groups.ok;
+const okGroupOrEmpty: { type: 'ok'; data: string }[] = groups.ok ?? [];
+const boundGroups = Result.groupBy(results);
+const boundOkGroup: { type: 'ok'; data: string }[] | undefined = boundGroups.ok;
 
 // filterMap — transforms and filters in one pass
 const lengths: number[] = filterMap(results, {
@@ -123,4 +126,4 @@ const lengths: number[] = filterMap(results, {
   // error and loading omitted — silently skipped
 });
 
-found; hasOk; allOk; multiSome; okGroup; lengths;
+found; hasOk; allOk; multiSome; okGroup; okGroupOrEmpty; boundOkGroup; lengths;


### PR DESCRIPTION
- Five new collection ops. find, some, every, groupBy, filterMap. all single-pass, variant-narrowed, and available as standalone
  functions and on createUnion/createPipeHandlers. New exported types: FilterMapHandlers<T, Result, D>, GroupByResult<T, D>.
  - Default now receives the triggering item. matchWithDefault and matchWithDefaultAsync call Default(item) instead of no arguments. Callers
   that declare no parameters are unaffected. Callers using Payload get Default(item, payload) instead of Default(payload). breaking for
  that subset.
  - README additions. plain-object emission highlighted at top, two re-export idioms documented (namespace style vs. exit-friendly style),
  new "Removing dismatch" section with mechanical rewrite recipe and incremental adoption example, comparison table gains Adoption & interop
  group and the four new collection ops as rows.
  - Bundle. canonical minified size is 3,250 B (3.17 KB), up ~805 B from 2.5.0; stays under the 4.0 KB cap. README and comparison table
  updated to reflect current size (~3.2 kB minified, ~1.5 kB gzipped).
  - Version bumped to 2.6.0.